### PR TITLE
Allow host to be specified for OAuth 2 token refresh

### DIFF
--- a/lib/metaforce/config.rb
+++ b/lib/metaforce/config.rb
@@ -39,8 +39,7 @@ module Metaforce
     attr_accessor :password
     # The security token to use during login.
     attr_accessor :security_token
-    # Set this to true if you're authenticating with a Sandbox instance.
-    # Defaults to false.
+    # The string hostname to use during authentication requests.
     attr_accessor :host
     # A block that gets called when the session becomes invalid and the
     # client needs to reauthenticate. Passes in the client and the client

--- a/lib/metaforce/login.rb
+++ b/lib/metaforce/login.rb
@@ -34,7 +34,7 @@ module Metaforce
       end.tap { |client| client.http.auth.ssl.verify_mode = :none }
     end
 
-    # Internal: Usernamed passed in from options.
+    # Internal: Username passed in from options.
     def username
       @username
     end

--- a/lib/metaforce/refresh.rb
+++ b/lib/metaforce/refresh.rb
@@ -17,6 +17,7 @@ module Metaforce
     # @option refresh_token [String]
     # @option client_id [String]
     # @option client_secret [String]
+    # @option host [String] Hostname for authentication requests.
     # @option authentication_calls [Proc] A proc that is called with the
     #   response body if the refresh is successful.
     def initialize(options = {})
@@ -58,9 +59,23 @@ module Metaforce
     end
     private :error_message
 
+    # Hostname for authentication requests.
+    # @return [String]
+    def host
+      @options[:host] || Metaforce.configuration.host
+    end
+    private :host
+
+    # URL for authentication requests.
+    # @return [String]
+    def login_url
+      "https://#{host}"
+    end
+    private :login_url
+
     # Faraday connection to use when sending an authentication request.
     def connection
-      @connection ||= Faraday.new('https://login.salesforce.com') do |builder|
+      @connection ||= Faraday.new(login_url) do |builder|
         builder.response :json
         builder.adapter Faraday.default_adapter
       end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -5,6 +5,11 @@ describe Metaforce do
     let(:api_version) { '29.0' }
     subject { Metaforce.configuration }
 
+    before do
+      Metaforce.configuration.host = nil
+      Metaforce.configuration.api_version = nil
+    end
+
     it { should set_default(:api_version).to(api_version) }
 
     it { should set_default(:host).to('login.salesforce.com') }

--- a/spec/lib/refresh_spec.rb
+++ b/spec/lib/refresh_spec.rb
@@ -26,57 +26,93 @@ describe Metaforce::Refresh do
            })
   end
 
-  before(:each) do
-    Faraday.should_receive(:new).with(login_url).
-        and_return(connection)
-  end
+  describe 'private #login_url' do
+    context 'by default' do
+      before { args.delete(:host) }
 
-  it 'makes a post request to get a new access token' do
-    connection.should_receive(:post) do |*args, &block|
-      args.first.should == '/services/oauth2/token'
-      request = OpenStruct.new(:body => nil)
-      block.call(request)
-      request.body.should == params
-    end.and_return(success_response)
-
-    trigger
-  end
-
-  it 'returns a hash with the new session_id/access_token' do
-    connection.stub(:post).and_return(success_response)
-
-    trigger.should == { :session_id => 'refreshed' }
-  end
-
-  context 'when the request returns an error' do
-    it 'raises an error' do
-      connection.stub(:post).and_return(failure_response)
-
-      expect { trigger }.to raise_error('Unauthorized: Access Denied')
-    end
-  end
-
-  context 'when an authentication callback is specified' do
-    let(:callback) { double('Proc') }
-
-    before(:each) do
-      args.merge!(:authentication_callback => callback)
-    end
-
-    context 'when the request returns an error' do
-      it 'does not call the authentication callback' do
-        connection.stub(:post).and_return(failure_response)
-        callback.should_not_receive(:call)
-
-        expect { trigger }.to raise_error
+      it 'returns https://login.salesforce.com' do
+        instance.send(:login_url).should == login_url
       end
     end
 
-    it 'calls the callback with the response body' do
-      connection.stub(:post).and_return(success_response)
-      callback.should_receive(:call).with('access_token' => 'refreshed')
+    context 'when host is unspecified' do
+      before do
+        args.delete(:host)
+        Metaforce.configuration.host = 'test.salesforce.com'
+      end
+
+      after do
+        Metaforce.configuration.host = nil
+      end
+
+      it 'uses Metaforce.configuration.host' do
+        instance.send(:login_url).should == 'https://test.salesforce.com'
+      end
+    end
+
+    context 'when host option is specified' do
+      before do
+        args.merge!(:host => 'test.salesforce.com')
+      end
+
+      it 'overrides Metaforce.configuration.host' do
+        instance.send(:login_url).should == 'https://test.salesforce.com'
+      end
+    end
+  end
+
+  describe '#refresh' do
+    before(:each) do
+      Faraday.stub(:new).with(login_url).and_return(connection)
+    end
+
+    it 'makes a post request to get a new access token' do
+      connection.should_receive(:post) do |*args, &block|
+        args.first.should == '/services/oauth2/token'
+        request = OpenStruct.new(:body => nil)
+        block.call(request)
+        request.body.should == params
+      end.and_return(success_response)
 
       trigger
+    end
+
+    it 'returns a hash with the new session_id/access_token' do
+      connection.stub(:post).and_return(success_response)
+
+      trigger.should == { :session_id => 'refreshed' }
+    end
+
+    context 'when the request returns an error' do
+      it 'raises an error' do
+        connection.stub(:post).and_return(failure_response)
+
+        expect { trigger }.to raise_error('Unauthorized: Access Denied')
+      end
+    end
+
+    context 'when an authentication callback is specified' do
+      let(:callback) { double('Proc') }
+
+      before(:each) do
+        args.merge!(:authentication_callback => callback)
+      end
+
+      context 'when the request returns an error' do
+        it 'does not call the authentication callback' do
+          connection.stub(:post).and_return(failure_response)
+          callback.should_not_receive(:call)
+
+          expect { trigger }.to raise_error
+        end
+      end
+
+      it 'calls the callback with the response body' do
+        connection.stub(:post).and_return(success_response)
+        callback.should_receive(:call).with('access_token' => 'refreshed')
+
+        trigger
+      end
     end
   end
 end


### PR DESCRIPTION
Most of the changes in `refresh_spec.rb` are just moving existing specs into a describe block.
