### PR TITLE
Update to version 34.0 of the metadata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,42 +92,51 @@ client.retrieve_unpackaged(manifest)
 
 * * *
 
-### create(type, metadata={})
+### create_metadata(type, metadata={})
 
 Takes a Symbol type and a Hash of [Metadata Attributes](http://www.salesforce.com/us/developer/docs/api_meta/Content/meta_types_list.htm)
 and returns a `Metaforce::Job::CRUD`.
 
 ```ruby
-client.create(:apex_page, full_name: 'Foobar', content: 'Hello World!')
-  .on_complete { |job| puts "ApexPage created." }
+client.create_metadata(:apex_page, full_name: 'Foobar', content: 'Hello World!')
   .perform
 #=> #<Metaforce::Job::CRUD @id='1234'>
 ```
 
 * * *
 
-### update(type, current\_name metadata={})
+### update_metadata(type, current\_name metadata={})
 
 Takes a Symbol type, the current `full_name` of the resource, and a Hash of
 [Metadata Attributes](http://www.salesforce.com/us/developer/docs/api_meta/Content/meta_types_list.htm)
 and returns a `Metaforce::Job::CRUD`.
 
 ```ruby
-client.update(:apex_page, 'Foobar', content: 'Hello World! Some new content!')
-  .on_complete { |job| puts "ApexPage updated." }
+client.update_metadata(:apex_page, 'Foobar', content: 'Hello World! Some new content!')
   .perform
 #=> #<Metaforce::Job::CRUD @id='1234'>
 ```
 
 * * *
 
-### delete(type, \*args)
+### delete_metadata(type, \*args)
 
 Takes a Symbol type, and the `full_name` of a resource and returns a `Metaforce::Job::CRUD`.
 
 ```ruby
 client.delete(:apex_page, 'Foobar')
-  .on_complete { |job| puts "ApexPage deleted." }
+  .perform
+#=> #<Metaforce::Job::CRUD @id='1234'>
+```
+
+* * *
+
+### read_metadata(type, \*args)
+
+Takes a Symbol type, and the `full_name` of a resource and returns a `Metaforce::Job::CRUD`.
+
+```ruby
+client.read_metadata(:apex_page, 'Foobar')
   .perform
 #=> #<Metaforce::Job::CRUD @id='1234'>
 ```

--- a/lib/metaforce.rb
+++ b/lib/metaforce.rb
@@ -7,6 +7,7 @@ Nori.convert_tags_to do |tag|
 end
 
 require 'hashie'
+require 'active_support/dependencies/autoload'
 require 'active_support/core_ext'
 
 require 'metaforce/version'

--- a/lib/metaforce/config.rb
+++ b/lib/metaforce/config.rb
@@ -56,7 +56,7 @@ module Metaforce
     end
 
     def api_version
-      @api_version ||= '29.0'
+      @api_version ||= '34.0'
     end
 
     def host

--- a/lib/metaforce/job/crud.rb
+++ b/lib/metaforce/job/crud.rb
@@ -5,9 +5,10 @@ module Metaforce
       @method, @args = method, args
     end
 
+    # All CRUD operations are synchronous starting with version 31, so this can
+    # just send the method directly to the client
     def perform
-      @id = @client.send(@method, *@args).id
-      super
+      @client.send(@method, *@args)
     end
   end
 end

--- a/lib/metaforce/login.rb
+++ b/lib/metaforce/login.rb
@@ -22,7 +22,12 @@ module Metaforce
           :password => password
         }
       end
-      response.body[:loginResponse][:result]
+
+      # The global override to convert the SOAP XML to camel case breaks the
+      # client options set by callers of this method, so undo it.
+      response.body[:loginResponse][:result].reduce({}) do |hash, (k, v)|
+        hash.merge(k.to_s.underscore.to_sym => v)
+      end
     end
 
   private

--- a/lib/metaforce/metadata/client/crud.rb
+++ b/lib/metaforce/metadata/client/crud.rb
@@ -7,10 +7,13 @@ module Metaforce
         #
         # Examples
         #
-        #   client._create(:apex_page, :full_name => 'TestPage', label: 'Test page', :content => '<apex:page>foobar</apex:page>')
-        def _create(type, metadata={})
+        #   client._create_metadata(:apex_page,
+        #                           :full_name => 'TestPage',
+        #                           :label => 'Test page',
+        #                           :content => '<apex:page>foobar</apex:page>')
+        def _create_metadata(type, metadata={})
           type = type.to_s.camelize
-          request :create do |soap|
+          request :create_metadata do |soap|
             soap.body = {
               :metadata => prepare(metadata)
             }.merge(attributes!(type))
@@ -21,14 +24,14 @@ module Metaforce
         #
         # Examples
         #
-        #   client._delete(:apex_component, 'Component')
-        def _delete(type, *args)
+        #   client._delete_metadata(:apex_component, 'Component')
+        def _delete_metadata(type, *args)
           type = type.to_s.camelize
-          metadata = args.map { |full_name| {:full_name => full_name} }
-          request :delete do |soap|
+          request :delete_metadata do |soap|
             soap.body = {
-              :metadata => metadata
-            }.merge(attributes!(type))
+              :type => type,
+              :full_name => args
+            }
           end
         end
 
@@ -36,30 +39,48 @@ module Metaforce
         #
         # Examples
         #
-        #   client._update(:apex_page, 'OldPage', :full_name => 'TestPage', :label => 'Test page', :content => '<apex:page>hello world</apex:page>')
-        def _update(type, current_name, metadata={})
+        #   client._update_metadata(:apex_page,
+        #                           :full_name => 'TestPage',
+        #                           :label => 'Test page',
+        #                           :content => '<apex:page>hello world</apex:page>')
+        def _update_metadata(type, metadata={})
           type = type.to_s.camelize
-          request :update do |soap|
+          request :update_metadata do |soap|
             soap.body = {
-              :metadata => {
-                :current_name => current_name,
-                :metadata => prepare(metadata),
-                :attributes! => { :metadata => { 'xsi:type' => "ins0:#{type}" } }
-              }
+              :metadata => prepare(metadata)
+            }.merge(attributes!(type))
+          end
+        end
+
+        # Public: Read metadata
+        #
+        # Examples
+        #
+        #   client._read_metadata(:apex_component, 'Component')
+        def _read_metadata(type, *args)
+          type = type.to_s.camelize
+          request :read_metadata do |soap|
+            soap.body = {
+              :type => type,
+              :full_name => args
             }
           end
         end
 
-        def create(*args)
-          Job::CRUD.new(self, :_create, args)
+        def create_metadata(*args)
+          Job::CRUD.new(self, :_create_metadata, args)
         end
 
-        def update(*args)
-          Job::CRUD.new(self, :_update, args)
+        def read_metadata(*args)
+          Job::CRUD.new(self, :_read_metadata, args)
         end
 
-        def delete(*args)
-          Job::CRUD.new(self, :_delete, args)
+        def update_metadata(*args)
+          Job::CRUD.new(self, :_update_metadata, args)
+        end
+
+        def delete_metadata(*args)
+          Job::CRUD.new(self, :_delete_metadata, args)
         end
 
       private

--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -31,7 +31,7 @@ EOL
   s.add_dependency 'faraday'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'savon_spec', '~> 1.3.0'
 end

--- a/spec/fixtures/package.xml
+++ b/spec/fixtures/package.xml
@@ -13,5 +13,5 @@
     <members>Assets</members>
     <name>StaticResource</name>
   </types>
-  <version>29.0</version>
+  <version>34.0</version>
 </Package>

--- a/spec/fixtures/requests/create_metadata/result.xml
+++ b/spec/fixtures/requests/create_metadata/result.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
   <soapenv:Body>
-    <deleteResponse>
+    <createMetadataResponse>
       <result>
-        <done>false</done>
-        <id>04sU0000000WNWoIAO</id>
-        <state>InProgress</state>
+        <fullName>Lead.Foo_Bar__c</fullName>
+        <success>true</success>
       </result>
-    </deleteResponse>
+    </createMetadataResponse>
   </soapenv:Body>
 </soapenv:Envelope>

--- a/spec/fixtures/requests/delete_metadata/result.xml
+++ b/spec/fixtures/requests/delete_metadata/result.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
   <soapenv:Body>
-    <updateResponse>
+    <deleteMetadataResponse>
       <result>
-        <done>false</done>
-        <id>04sU0000000WNWoIAO</id>
-        <state>InProgress</state>
+        <fullName>component</fullName>
+        <success>true</success>
       </result>
-    </updateResponse>
+    </deleteMetadataResponse>
   </soapenv:Body>
 </soapenv:Envelope>

--- a/spec/fixtures/requests/read_metadata/result.xml
+++ b/spec/fixtures/requests/read_metadata/result.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <readMetadataResponse>
+      <result>
+        <records xsi:type="CustomField">
+          <fullName>Lead.Foo_Bar__c</fullName>
+          <externalId>false</externalId>
+          <label>Foo Bar</label>
+          <length>20</length>
+          <required>false</required>
+          <trackFeedHistory>false</trackFeedHistory>
+          <type>Text</type>
+          <unique>false</unique>
+        </records>
+      </result>
+    </readMetadataResponse>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/fixtures/requests/update_metadata/result.xml
+++ b/spec/fixtures/requests/update_metadata/result.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
   <soapenv:Body>
-    <createResponse>
+    <updateMetadataResponse>
       <result>
-        <done>false</done>
-        <id>04sU0000000WNWoIAO</id>
-        <state>InProgress</state>
+        <fullName>component</fullName>
+        <success>true</success>
       </result>
-    </createResponse>
+    </updateMetadataResponse>
   </soapenv:Body>
 </soapenv:Envelope>

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Metaforce do
   describe '.configuration' do
-    let(:api_version) { '29.0' }
+    let(:api_version) { '34.0' }
     subject { Metaforce.configuration }
 
     before do

--- a/spec/lib/job/retrieve_spec.rb
+++ b/spec/lib/job/retrieve_spec.rb
@@ -22,7 +22,7 @@ describe Metaforce::Job::Retrieve do
       client.should_receive(:status).with(job.id, :retrieve).and_return(response)
     end
 
-    subject { job.zip_file }
-    it { should eq "~\x8A\e" }
+    subject { job.zip_file.bytes }
+    it { should eq [126, 138, 27, 106] }
   end
 end

--- a/spec/lib/login_spec.rb
+++ b/spec/lib/login_spec.rb
@@ -14,18 +14,18 @@ describe Metaforce::Login do
 
     it { should be_a Hash }
 
-    its([:sessionId]) do
+    its([:session_id]) do
       should == '00DU0000000Ilbh!AQoAQHVcube9Z6CRlbR9Eg'\
                 '8ZxpJlrJ6X8QDbnokfyVZItFKzJsLH'\
                 'IRGiqhzJkYsNYRkd3UVA9.s82sbjEbZGUqP3mG6TP_P8'
     end
 
-    its([:metadataServerUrl]) do
+    its([:metadata_server_url]) do
       should == \
           'https://na12-api.salesforce.com/services/Soap/m/29.0/00DU0000000Albh'
     end
 
-    its([:serverUrl]) do
+    its([:server_url]) do
       should == \
           'https://na12-api.salesforce.com/services/Soap/u/29.0/00DU0000000Ilbh'
     end

--- a/spec/lib/metadata/client_spec.rb
+++ b/spec/lib/metadata/client_spec.rb
@@ -92,42 +92,120 @@ describe Metaforce::Metadata::Client do
     it { should be_a Metaforce::Job::Retrieve }
   end
 
-  describe '._create' do
+  describe '._create_metadata' do
     before do
-      savon.expects(:create).with(:metadata => [{:full_name => 'component', :label => 'test', :content => "Zm9vYmFy\n"}], :attributes! => {'ins0:metadata' => {'xsi:type' => 'ins0:ApexComponent'}}).returns(:in_progress)
+      savon.expects(:create_metadata).
+          with({
+                 :metadata =>
+                 [
+                   {
+                     :full_name => 'component',
+                     :label => 'test',
+                     :content => "Zm9vYmFy\n"
+                   }
+                 ],
+                 :attributes! =>
+                 {
+                   'ins0:metadata' => { 'xsi:type' => 'ins0:ApexComponent' }
+                 }
+               }).returns(:result)
     end
 
-    subject { client._create(:apex_component, :full_name => 'component', :label => 'test', :content => 'foobar') }
+    subject do
+      client._create_metadata(:apex_component,
+                              :full_name => 'component',
+                              :label => 'test',
+                              :content => 'foobar')
+    end
+
     it { should be_a Hash }
   end
 
-  describe '._delete' do
+  describe '._delete_metadata' do
     context 'with a single name' do
       before do
-        savon.expects(:delete).with(:metadata => [{:full_name => 'component'}], :attributes! => {'ins0:metadata' => {'xsi:type' => 'ins0:ApexComponent'}}).returns(:in_progress)
+        savon.expects(:delete_metadata).with({
+                                               :type => 'ApexComponent',
+                                               :full_name => ['component']
+                                             }).returns(:result)
       end
 
-      subject { client._delete(:apex_component, 'component') }
+      subject { client._delete_metadata(:apex_component, 'component') }
       it { should be_a Hash }
     end
 
     context 'with multiple' do
       before do
-        savon.expects(:delete).with(:metadata => [{:full_name => 'component1'}, {:full_name => 'component2'}], :attributes! => {'ins0:metadata' => {'xsi:type' => 'ins0:ApexComponent'}}).returns(:in_progress)
+        savon.expects(:delete_metadata).with({
+                                               :type => 'ApexComponent',
+                                               :full_name => ['component1', 'component2']
+                                             }).returns(:result)
       end
 
-      subject { client._delete(:apex_component, 'component1', 'component2') }
+      subject { client._delete_metadata(:apex_component, 'component1', 'component2') }
       it { should be_a Hash }
     end
   end
 
-  describe '._update' do
+  describe '._update_metadata' do
     before do
-      savon.expects(:update).with(:metadata => {:current_name => 'old_component', :metadata => [{:full_name => 'component', :label => 'test', :content => "Zm9vYmFy\n"}], :attributes! => {:metadata => {'xsi:type' => 'ins0:ApexComponent'}}}).returns(:in_progress)
+      savon.expects(:update_metadata).
+        with({
+               :metadata =>
+               [
+                 {
+                   :full_name => 'component',
+                   :label => 'test',
+                   :content => "Zm9vYmFy\n"
+                 }
+               ],
+               :attributes! =>
+               {
+                 "ins0:metadata" => {'xsi:type' => 'ins0:ApexComponent'}
+               }
+             }).returns(:result)
     end
 
-    subject { client._update(:apex_component, 'old_component', :full_name => 'component', :label => 'test', :content => 'foobar') }
+    subject do
+      client._update_metadata(:apex_component,
+                              :full_name => 'component',
+                              :label => 'test',
+                              :content => 'foobar')
+    end
+
     it { should be_a Hash }
+  end
+
+  describe '._read_metadata' do
+    before do
+      savon.expects(:read_metadata).with({
+                                           :type => 'CustomField',
+                                           :full_name => ['Lead.Foo_Bar__c']
+                                         }).returns(:result)
+    end
+
+    subject do
+      client._read_metadata(:custom_field, 'Lead.Foo_Bar__c')
+    end
+
+    let(:expected) do
+      {
+        'records' =>
+        {
+          '@xsi:type' => 'CustomField',
+          'externalId' => false,
+          'fullName' => 'Lead.Foo_Bar__c',
+          'label' => 'Foo Bar',
+          'length' => '20',
+          'required' => false,
+          'trackFeedHistory' => false,
+          'type' => 'Text',
+          'unique' => false
+        }
+      }
+    end
+
+    it { should eq expected }
   end
 end
 

--- a/spec/lib/metaforce/job/crud_spec.rb
+++ b/spec/lib/metaforce/job/crud_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Metaforce::Job::CRUD do
+  let(:client) { double('client') }
+  let(:method) { :my_method }
+  let(:args) { double('args') }
+  let(:instance) { described_class.new(client, method, args) }
+
+  describe '#perform' do
+    let(:response) { double('response') }
+
+    before(:each) do
+      client.stub(method).and_return(response)
+    end
+
+    it 'calls the client' do
+      client.should_receive(method).with(args)
+
+      instance.perform
+    end
+
+    it 'returns the client response' do
+      instance.perform.should == response
+    end
+  end
+end

--- a/wsdl/34.0/metadata.xml
+++ b/wsdl/34.0/metadata.xml
@@ -1,0 +1,7983 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Salesforce.com Metadata API version 34.0
+
+Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
+-->
+<definitions targetNamespace="http://soap.sforce.com/2006/04/metadata" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://soap.sforce.com/2006/04/metadata">
+ <types>
+  <xsd:schema elementFormDefault="qualified" targetNamespace="http://soap.sforce.com/2006/04/metadata">
+   <xsd:complexType name="CancelDeployResult">
+    <xsd:sequence>
+     <xsd:element name="done" type="xsd:boolean"/>
+     <xsd:element name="id" type="tns:ID"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeployResult">
+    <xsd:sequence>
+     <xsd:element name="canceledBy" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="canceledByName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="checkOnly" type="xsd:boolean"/>
+     <xsd:element name="completedDate" minOccurs="0" type="xsd:dateTime"/>
+     <xsd:element name="createdBy" type="xsd:string"/>
+     <xsd:element name="createdByName" type="xsd:string"/>
+     <xsd:element name="createdDate" type="xsd:dateTime"/>
+     <xsd:element name="details" type="tns:DeployDetails"/>
+     <xsd:element name="done" type="xsd:boolean"/>
+     <xsd:element name="errorMessage" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="errorStatusCode" minOccurs="0" type="tns:StatusCode"/>
+     <xsd:element name="id" type="tns:ID"/>
+     <xsd:element name="ignoreWarnings" type="xsd:boolean"/>
+     <xsd:element name="lastModifiedDate" minOccurs="0" type="xsd:dateTime"/>
+     <xsd:element name="numberComponentErrors" type="xsd:int"/>
+     <xsd:element name="numberComponentsDeployed" type="xsd:int"/>
+     <xsd:element name="numberComponentsTotal" type="xsd:int"/>
+     <xsd:element name="numberTestErrors" type="xsd:int"/>
+     <xsd:element name="numberTestsCompleted" type="xsd:int"/>
+     <xsd:element name="numberTestsTotal" type="xsd:int"/>
+     <xsd:element name="rollbackOnError" type="xsd:boolean"/>
+     <xsd:element name="runTestsEnabled" type="xsd:boolean"/>
+     <xsd:element name="startDate" minOccurs="0" type="xsd:dateTime"/>
+     <xsd:element name="stateDetail" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="status" type="tns:DeployStatus"/>
+     <xsd:element name="success" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeployDetails">
+    <xsd:sequence>
+     <xsd:element name="componentFailures" minOccurs="0" maxOccurs="unbounded" type="tns:DeployMessage"/>
+     <xsd:element name="componentSuccesses" minOccurs="0" maxOccurs="unbounded" type="tns:DeployMessage"/>
+     <xsd:element name="retrieveResult" minOccurs="0" type="tns:RetrieveResult"/>
+     <xsd:element name="runTestResult" minOccurs="0" type="tns:RunTestsResult"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeployMessage">
+    <xsd:sequence>
+     <xsd:element name="changed" type="xsd:boolean"/>
+     <xsd:element name="columnNumber" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="componentType" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="created" type="xsd:boolean"/>
+     <xsd:element name="createdDate" type="xsd:dateTime"/>
+     <xsd:element name="deleted" type="xsd:boolean"/>
+     <xsd:element name="fileName" type="xsd:string"/>
+     <xsd:element name="fullName" type="xsd:string"/>
+     <xsd:element name="id" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="lineNumber" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="problem" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="problemType" minOccurs="0" type="tns:DeployProblemType"/>
+     <xsd:element name="success" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="DeployProblemType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Warning"/>
+     <xsd:enumeration value="Error"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="RetrieveResult">
+    <xsd:sequence>
+     <xsd:element name="done" type="xsd:boolean"/>
+     <xsd:element name="errorMessage" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="errorStatusCode" minOccurs="0" type="tns:StatusCode"/>
+     <xsd:element name="fileProperties" minOccurs="0" maxOccurs="unbounded" type="tns:FileProperties"/>
+     <xsd:element name="id" type="xsd:string"/>
+     <xsd:element name="messages" minOccurs="0" maxOccurs="unbounded" type="tns:RetrieveMessage"/>
+     <xsd:element name="status" type="tns:RetrieveStatus"/>
+     <xsd:element name="success" type="xsd:boolean"/>
+     <xsd:element name="zipFile" type="xsd:base64Binary"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FileProperties">
+    <xsd:sequence>
+     <xsd:element name="createdById" type="xsd:string"/>
+     <xsd:element name="createdByName" type="xsd:string"/>
+     <xsd:element name="createdDate" type="xsd:dateTime"/>
+     <xsd:element name="fileName" type="xsd:string"/>
+     <xsd:element name="fullName" type="xsd:string"/>
+     <xsd:element name="id" type="xsd:string"/>
+     <xsd:element name="lastModifiedById" type="xsd:string"/>
+     <xsd:element name="lastModifiedByName" type="xsd:string"/>
+     <xsd:element name="lastModifiedDate" type="xsd:dateTime"/>
+     <xsd:element name="manageableState" minOccurs="0" type="tns:ManageableState"/>
+     <xsd:element name="namespacePrefix" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="type" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ManageableState">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="released"/>
+     <xsd:enumeration value="deleted"/>
+     <xsd:enumeration value="deprecated"/>
+     <xsd:enumeration value="installed"/>
+     <xsd:enumeration value="beta"/>
+     <xsd:enumeration value="unmanaged"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="RetrieveMessage">
+    <xsd:sequence>
+     <xsd:element name="fileName" type="xsd:string"/>
+     <xsd:element name="problem" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="RetrieveStatus">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Pending"/>
+     <xsd:enumeration value="InProgress"/>
+     <xsd:enumeration value="Succeeded"/>
+     <xsd:enumeration value="Failed"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="RunTestsResult">
+    <xsd:sequence>
+     <xsd:element name="codeCoverage" minOccurs="0" maxOccurs="unbounded" type="tns:CodeCoverageResult"/>
+     <xsd:element name="codeCoverageWarnings" minOccurs="0" maxOccurs="unbounded" type="tns:CodeCoverageWarning"/>
+     <xsd:element name="failures" minOccurs="0" maxOccurs="unbounded" type="tns:RunTestFailure"/>
+     <xsd:element name="numFailures" type="xsd:int"/>
+     <xsd:element name="numTestsRun" type="xsd:int"/>
+     <xsd:element name="successes" minOccurs="0" maxOccurs="unbounded" type="tns:RunTestSuccess"/>
+     <xsd:element name="totalTime" type="xsd:double"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CodeCoverageResult">
+    <xsd:sequence>
+     <xsd:element name="dmlInfo" minOccurs="0" maxOccurs="unbounded" type="tns:CodeLocation"/>
+     <xsd:element name="id" type="tns:ID"/>
+     <xsd:element name="locationsNotCovered" minOccurs="0" maxOccurs="unbounded" type="tns:CodeLocation"/>
+     <xsd:element name="methodInfo" minOccurs="0" maxOccurs="unbounded" type="tns:CodeLocation"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="namespace" type="xsd:string" nillable="true"/>
+     <xsd:element name="numLocations" type="xsd:int"/>
+     <xsd:element name="numLocationsNotCovered" type="xsd:int"/>
+     <xsd:element name="soqlInfo" minOccurs="0" maxOccurs="unbounded" type="tns:CodeLocation"/>
+     <xsd:element name="soslInfo" minOccurs="0" maxOccurs="unbounded" type="tns:CodeLocation"/>
+     <xsd:element name="type" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CodeLocation">
+    <xsd:sequence>
+     <xsd:element name="column" type="xsd:int"/>
+     <xsd:element name="line" type="xsd:int"/>
+     <xsd:element name="numExecutions" type="xsd:int"/>
+     <xsd:element name="time" type="xsd:double"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CodeCoverageWarning">
+    <xsd:sequence>
+     <xsd:element name="id" type="tns:ID"/>
+     <xsd:element name="message" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string" nillable="true"/>
+     <xsd:element name="namespace" type="xsd:string" nillable="true"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RunTestFailure">
+    <xsd:sequence>
+     <xsd:element name="id" type="tns:ID"/>
+     <xsd:element name="message" type="xsd:string"/>
+     <xsd:element name="methodName" type="xsd:string" nillable="true"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="namespace" type="xsd:string" nillable="true"/>
+     <xsd:element name="packageName" type="xsd:string"/>
+     <xsd:element name="seeAllData" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="stackTrace" type="xsd:string" nillable="true"/>
+     <xsd:element name="time" type="xsd:double"/>
+     <xsd:element name="type" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RunTestSuccess">
+    <xsd:sequence>
+     <xsd:element name="id" type="tns:ID"/>
+     <xsd:element name="methodName" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="namespace" type="xsd:string" nillable="true"/>
+     <xsd:element name="seeAllData" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="time" type="xsd:double"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="DeployStatus">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Pending"/>
+     <xsd:enumeration value="InProgress"/>
+     <xsd:enumeration value="Succeeded"/>
+     <xsd:enumeration value="SucceededPartial"/>
+     <xsd:enumeration value="Failed"/>
+     <xsd:enumeration value="Canceling"/>
+     <xsd:enumeration value="Canceled"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="Metadata">
+    <xsd:sequence>
+     <xsd:element name="fullName" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AccountSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableAccountOwnerReport" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableAccountTeams" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSharedContacts" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showViewHierarchyLink" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActionLinkGroupTemplate">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="actionLinkTemplates" minOccurs="0" maxOccurs="unbounded" type="tns:ActionLinkTemplate"/>
+       <xsd:element name="category" type="tns:PlatformActionGroupCategory"/>
+       <xsd:element name="executionsAllowed" type="tns:ActionLinkExecutionsAllowed"/>
+       <xsd:element name="hoursUntilExpiration" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="isPublished" type="xsd:boolean"/>
+       <xsd:element name="name" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActionLinkTemplate">
+    <xsd:sequence>
+     <xsd:element name="actionUrl" type="xsd:string"/>
+     <xsd:element name="headers" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="isConfirmationRequired" type="xsd:boolean"/>
+     <xsd:element name="isGroupDefault" type="xsd:boolean"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="labelKey" type="xsd:string"/>
+     <xsd:element name="linkType" type="tns:ActionLinkType"/>
+     <xsd:element name="method" type="tns:ActionLinkHttpMethod"/>
+     <xsd:element name="position" type="xsd:int"/>
+     <xsd:element name="requestBody" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="userAlias" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="userVisibility" type="tns:ActionLinkUserVisibility"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ActionLinkType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="API"/>
+     <xsd:enumeration value="APIAsync"/>
+     <xsd:enumeration value="Download"/>
+     <xsd:enumeration value="UI"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ActionLinkHttpMethod">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="HttpDelete"/>
+     <xsd:enumeration value="HttpHead"/>
+     <xsd:enumeration value="HttpGet"/>
+     <xsd:enumeration value="HttpPatch"/>
+     <xsd:enumeration value="HttpPost"/>
+     <xsd:enumeration value="HttpPut"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ActionLinkUserVisibility">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Creator"/>
+     <xsd:enumeration value="Everyone"/>
+     <xsd:enumeration value="EveryoneButCreator"/>
+     <xsd:enumeration value="Manager"/>
+     <xsd:enumeration value="CustomUser"/>
+     <xsd:enumeration value="CustomExcludedUser"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="PlatformActionGroupCategory">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Primary"/>
+     <xsd:enumeration value="Overflow"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ActionLinkExecutionsAllowed">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Once"/>
+     <xsd:enumeration value="OncePerUser"/>
+     <xsd:enumeration value="Unlimited"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ActivitiesSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="allowUsersToRelateMultipleContactsToTasksAndEvents" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableActivityReminders" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableClickCreateEvents" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableDragAndDropScheduling" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableEmailTracking" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableEventScheduler" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableGroupTasks" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableListViewScheduling" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableLogNote" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableMultidayEvents" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableRecurringEvents" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableRecurringTasks" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSidebarCalendarShortcut" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSimpleTaskCreateUI" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableUNSTaskDelegatedToNotifications" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="meetingRequestsLogo" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="showCustomLogoMeetingRequests" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showEventDetailsMultiUserCalendar" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showHomePageHoverLinksForEvents" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showMyTasksHoverLinks" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showRequestedMeetingsOnHomePage" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="countriesAndStates" type="tns:CountriesAndStates"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountriesAndStates">
+    <xsd:sequence>
+     <xsd:element name="countries" minOccurs="0" maxOccurs="unbounded" type="tns:Country"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Country">
+    <xsd:sequence>
+     <xsd:element name="active" type="xsd:boolean"/>
+     <xsd:element name="integrationValue" type="xsd:string"/>
+     <xsd:element name="isoCode" type="xsd:string"/>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="orgDefault" type="xsd:boolean"/>
+     <xsd:element name="standard" type="xsd:boolean"/>
+     <xsd:element name="states" minOccurs="0" maxOccurs="unbounded" type="tns:State"/>
+     <xsd:element name="visible" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="State">
+    <xsd:sequence>
+     <xsd:element name="active" type="xsd:boolean"/>
+     <xsd:element name="integrationValue" type="xsd:string"/>
+     <xsd:element name="isoCode" type="xsd:string"/>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="standard" type="xsd:boolean"/>
+     <xsd:element name="visible" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AnalyticSnapshot">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="groupColumn" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="mappings" minOccurs="0" maxOccurs="unbounded" type="tns:AnalyticSnapshotMapping"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="runningUser" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="sourceReport" type="xsd:string"/>
+       <xsd:element name="targetObject" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnalyticSnapshotMapping">
+    <xsd:sequence>
+     <xsd:element name="aggregateType" minOccurs="0" type="tns:ReportSummaryType"/>
+     <xsd:element name="sourceField" type="xsd:string"/>
+     <xsd:element name="sourceType" type="tns:ReportJobSourceTypes"/>
+     <xsd:element name="targetField" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ReportSummaryType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Sum"/>
+     <xsd:enumeration value="Average"/>
+     <xsd:enumeration value="Maximum"/>
+     <xsd:enumeration value="Minimum"/>
+     <xsd:enumeration value="None"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ReportJobSourceTypes">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="tabular"/>
+     <xsd:enumeration value="summary"/>
+     <xsd:enumeration value="snapshot"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="AppMenu">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="appMenuItems" minOccurs="0" maxOccurs="unbounded" type="tns:AppMenuItem"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="AppMenuItem">
+    <xsd:sequence>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="type" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalProcess">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="allowRecall" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="allowedSubmitters" minOccurs="0" maxOccurs="unbounded" type="tns:ApprovalSubmitter"/>
+       <xsd:element name="approvalPageFields" minOccurs="0" type="tns:ApprovalPageField"/>
+       <xsd:element name="approvalStep" minOccurs="0" maxOccurs="unbounded" type="tns:ApprovalStep"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="emailTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="enableMobileDeviceAccess" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="entryCriteria" minOccurs="0" type="tns:ApprovalEntryCriteria"/>
+       <xsd:element name="finalApprovalActions" minOccurs="0" type="tns:ApprovalAction"/>
+       <xsd:element name="finalApprovalRecordLock" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="finalRejectionActions" minOccurs="0" type="tns:ApprovalAction"/>
+       <xsd:element name="finalRejectionRecordLock" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="initialSubmissionActions" minOccurs="0" type="tns:ApprovalAction"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="nextAutomatedApprover" minOccurs="0" type="tns:NextAutomatedApprover"/>
+       <xsd:element name="postTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="recallActions" minOccurs="0" type="tns:ApprovalAction"/>
+       <xsd:element name="recordEditability" type="tns:RecordEditabilityType"/>
+       <xsd:element name="showApprovalHistory" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalSubmitter">
+    <xsd:sequence>
+     <xsd:element name="submitter" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="type" type="tns:ProcessSubmitterType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ProcessSubmitterType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="group"/>
+     <xsd:enumeration value="role"/>
+     <xsd:enumeration value="user"/>
+     <xsd:enumeration value="roleSubordinates"/>
+     <xsd:enumeration value="roleSubordinatesInternal"/>
+     <xsd:enumeration value="owner"/>
+     <xsd:enumeration value="creator"/>
+     <xsd:enumeration value="partnerUser"/>
+     <xsd:enumeration value="customerPortalUser"/>
+     <xsd:enumeration value="portalRole"/>
+     <xsd:enumeration value="portalRoleSubordinates"/>
+     <xsd:enumeration value="allInternalUsers"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ApprovalPageField">
+    <xsd:sequence>
+     <xsd:element name="field" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalStep">
+    <xsd:sequence>
+     <xsd:element name="allowDelegate" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="approvalActions" minOccurs="0" type="tns:ApprovalAction"/>
+     <xsd:element name="assignedApprover" type="tns:ApprovalStepApprover"/>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="entryCriteria" minOccurs="0" type="tns:ApprovalEntryCriteria"/>
+     <xsd:element name="ifCriteriaNotMet" minOccurs="0" type="tns:StepCriteriaNotMetType"/>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="rejectBehavior" minOccurs="0" type="tns:ApprovalStepRejectBehavior"/>
+     <xsd:element name="rejectionActions" minOccurs="0" type="tns:ApprovalAction"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalAction">
+    <xsd:sequence>
+     <xsd:element name="action" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowActionReference"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WorkflowActionReference">
+    <xsd:sequence>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="type" type="tns:WorkflowActionType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="WorkflowActionType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="FieldUpdate"/>
+     <xsd:enumeration value="KnowledgePublish"/>
+     <xsd:enumeration value="Task"/>
+     <xsd:enumeration value="Alert"/>
+     <xsd:enumeration value="Send"/>
+     <xsd:enumeration value="OutboundMessage"/>
+     <xsd:enumeration value="FlowAction"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ApprovalStepApprover">
+    <xsd:sequence>
+     <xsd:element name="approver" minOccurs="0" maxOccurs="unbounded" type="tns:Approver"/>
+     <xsd:element name="whenMultipleApprovers" minOccurs="0" type="tns:RoutingType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Approver">
+    <xsd:sequence>
+     <xsd:element name="name" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="type" type="tns:NextOwnerType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="NextOwnerType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="adhoc"/>
+     <xsd:enumeration value="user"/>
+     <xsd:enumeration value="userHierarchyField"/>
+     <xsd:enumeration value="relatedUserField"/>
+     <xsd:enumeration value="queue"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="RoutingType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Unanimous"/>
+     <xsd:enumeration value="FirstResponse"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ApprovalEntryCriteria">
+    <xsd:sequence>
+     <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="criteriaItems" minOccurs="0" maxOccurs="unbounded" type="tns:FilterItem"/>
+     <xsd:element name="formula" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FilterItem">
+    <xsd:sequence>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="operation" type="tns:FilterOperation"/>
+     <xsd:element name="value" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="valueField" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="FilterOperation">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="equals"/>
+     <xsd:enumeration value="notEqual"/>
+     <xsd:enumeration value="lessThan"/>
+     <xsd:enumeration value="greaterThan"/>
+     <xsd:enumeration value="lessOrEqual"/>
+     <xsd:enumeration value="greaterOrEqual"/>
+     <xsd:enumeration value="contains"/>
+     <xsd:enumeration value="notContain"/>
+     <xsd:enumeration value="startsWith"/>
+     <xsd:enumeration value="includes"/>
+     <xsd:enumeration value="excludes"/>
+     <xsd:enumeration value="within"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="StepCriteriaNotMetType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="ApproveRecord"/>
+     <xsd:enumeration value="RejectRecord"/>
+     <xsd:enumeration value="GotoNextStep"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ApprovalStepRejectBehavior">
+    <xsd:sequence>
+     <xsd:element name="type" type="tns:StepRejectBehaviorType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="StepRejectBehaviorType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="RejectRequest"/>
+     <xsd:enumeration value="BackToPrevious"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="NextAutomatedApprover">
+    <xsd:sequence>
+     <xsd:element name="useApproverFieldOfRecordOwner" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="userHierarchyField" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="RecordEditabilityType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AdminOnly"/>
+     <xsd:enumeration value="AdminOrCurrentApprover"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="AssignmentRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="ruleEntry" minOccurs="0" maxOccurs="unbounded" type="tns:RuleEntry"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="RuleEntry">
+    <xsd:sequence>
+     <xsd:element name="assignedTo" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="assignedToType" minOccurs="0" type="tns:AssignToLookupValueType"/>
+     <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="businessHours" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="businessHoursSource" minOccurs="0" type="tns:BusinessHoursSourceType"/>
+     <xsd:element name="criteriaItems" minOccurs="0" maxOccurs="unbounded" type="tns:FilterItem"/>
+     <xsd:element name="disableEscalationWhenModified" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="escalationAction" minOccurs="0" maxOccurs="unbounded" type="tns:EscalationAction"/>
+     <xsd:element name="escalationStartTime" minOccurs="0" type="tns:EscalationStartTimeType"/>
+     <xsd:element name="formula" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="notifyCcRecipients" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="overrideExistingTeams" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="replyToEmail" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="senderEmail" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="senderName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="team" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="template" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="AssignToLookupValueType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="User"/>
+     <xsd:enumeration value="Queue"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="BusinessHoursSourceType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Case"/>
+     <xsd:enumeration value="Static"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="EscalationAction">
+    <xsd:sequence>
+     <xsd:element name="assignedTo" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="assignedToTemplate" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="assignedToType" minOccurs="0" type="tns:AssignToLookupValueType"/>
+     <xsd:element name="minutesToEscalation" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="notifyCaseOwner" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="notifyEmail" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="notifyTo" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="notifyToTemplate" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="EscalationStartTimeType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="CaseCreation"/>
+     <xsd:enumeration value="CaseLastModified"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="AssignmentRules">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="assignmentRule" minOccurs="0" maxOccurs="unbounded" type="tns:AssignmentRule"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="AuraDefinitionBundle">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="SVGContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="controllerContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="designContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="documentationContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="helperContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="markup" type="xsd:base64Binary"/>
+       <xsd:element name="modelContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="rendererContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="styleContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="testsuiteContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="type" type="tns:AuraBundleType"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="AuraBundleType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Application"/>
+     <xsd:enumeration value="Component"/>
+     <xsd:enumeration value="Event"/>
+     <xsd:enumeration value="Interface"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="AuthProvider">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="authorizeUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="consumerKey" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="consumerSecret" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultScopes" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="errorUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="executionUser" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="friendlyName" type="xsd:string"/>
+       <xsd:element name="iconUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="idTokenIssuer" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="includeOrgIdInIdentifier" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="logoutUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="portal" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="providerType" type="tns:AuthProviderType"/>
+       <xsd:element name="registrationHandler" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="sendAccessTokenInHeader" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="sendClientCredentialsInHeader" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="tokenUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="userInfoUrl" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="AuthProviderType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Facebook"/>
+     <xsd:enumeration value="Janrain"/>
+     <xsd:enumeration value="Salesforce"/>
+     <xsd:enumeration value="OpenIdConnect"/>
+     <xsd:enumeration value="MicrosoftACS"/>
+     <xsd:enumeration value="LinkedIn"/>
+     <xsd:enumeration value="Twitter"/>
+     <xsd:enumeration value="Google"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="AutoResponseRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="ruleEntry" minOccurs="0" maxOccurs="unbounded" type="tns:RuleEntry"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="AutoResponseRules">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="autoResponseRule" minOccurs="0" maxOccurs="unbounded" type="tns:AutoResponseRule"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessHoursEntry">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="default" type="xsd:boolean"/>
+       <xsd:element name="fridayEndTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="fridayStartTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="mondayEndTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="mondayStartTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="name" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="saturdayEndTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="saturdayStartTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="sundayEndTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="sundayStartTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="thursdayEndTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="thursdayStartTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="timeZoneId" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="tuesdayEndTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="tuesdayStartTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="wednesdayEndTime" minOccurs="0" type="xsd:time"/>
+       <xsd:element name="wednesdayStartTime" minOccurs="0" type="xsd:time"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessHoursSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="businessHours" minOccurs="0" maxOccurs="unbounded" type="tns:BusinessHoursEntry"/>
+       <xsd:element name="holidays" minOccurs="0" maxOccurs="unbounded" type="tns:Holiday"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Holiday">
+    <xsd:sequence>
+     <xsd:element name="activityDate" minOccurs="0" type="xsd:date"/>
+     <xsd:element name="businessHours" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="endTime" minOccurs="0" type="xsd:time"/>
+     <xsd:element name="isRecurring" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="name" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="recurrenceDayOfMonth" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="recurrenceDayOfWeek" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="recurrenceDayOfWeekMask" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="recurrenceEndDate" minOccurs="0" type="xsd:date"/>
+     <xsd:element name="recurrenceInstance" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="recurrenceInterval" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="recurrenceMonthOfYear" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="recurrenceStartDate" minOccurs="0" type="xsd:date"/>
+     <xsd:element name="recurrenceType" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="startTime" minOccurs="0" type="xsd:time"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessProcess">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="isActive" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="values" minOccurs="0" maxOccurs="unbounded" type="tns:PicklistValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PicklistValue">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="allowEmail" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="closed" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="color" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="controllingFieldValues" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="converted" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="cssExposed" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="default" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="forecastCategory" minOccurs="0" type="tns:ForecastCategories"/>
+       <xsd:element name="highPriority" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="probability" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="reverseRole" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="reviewed" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="won" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="ForecastCategories">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Omitted"/>
+     <xsd:enumeration value="Pipeline"/>
+     <xsd:enumeration value="BestCase"/>
+     <xsd:enumeration value="Forecast"/>
+     <xsd:enumeration value="Closed"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CallCenter">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="adapterUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="customSettings" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="displayName" type="xsd:string"/>
+       <xsd:element name="displayNameLabel" type="xsd:string"/>
+       <xsd:element name="internalNameLabel" type="xsd:string"/>
+       <xsd:element name="sections" minOccurs="0" maxOccurs="unbounded" type="tns:CallCenterSection"/>
+       <xsd:element name="version" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallCenterSection">
+    <xsd:sequence>
+     <xsd:element name="items" minOccurs="0" maxOccurs="unbounded" type="tns:CallCenterItem"/>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CallCenterItem">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="value" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CaseSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="caseAssignNotificationTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="caseCloseNotificationTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="caseCommentNotificationTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="caseCreateNotificationTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="caseFeedItemSettings" minOccurs="0" maxOccurs="unbounded" type="tns:FeedItemSettings"/>
+       <xsd:element name="closeCaseThroughStatusChange" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="defaultCaseOwner" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultCaseOwnerType" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultCaseUser" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="emailActionDefaultsHandlerClass" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="emailToCase" minOccurs="0" type="tns:EmailToCaseSettings"/>
+       <xsd:element name="enableCaseFeed" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableDraftEmails" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableEarlyEscalationRuleTriggers" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableEmailActionDefaultsHandler" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSuggestedArticlesApplication" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSuggestedArticlesCustomerPortal" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSuggestedArticlesPartnerPortal" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSuggestedSolutions" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="keepRecordTypeOnAssignmentRule" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="notifyContactOnCaseComment" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="notifyDefaultCaseOwner" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="notifyOwnerOnCaseComment" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="notifyOwnerOnCaseOwnerChange" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showFewerCloseActions" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="useSystemEmailAddress" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="webToCase" minOccurs="0" type="tns:WebToCaseSettings"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeedItemSettings">
+    <xsd:sequence>
+     <xsd:element name="characterLimit" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="collapseThread" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="displayFormat" minOccurs="0" type="tns:FeedItemDisplayFormat"/>
+     <xsd:element name="feedItemType" type="tns:FeedItemType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="FeedItemDisplayFormat">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Default"/>
+     <xsd:enumeration value="HideBlankLines"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="FeedItemType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="TrackedChange"/>
+     <xsd:enumeration value="UserStatus"/>
+     <xsd:enumeration value="TextPost"/>
+     <xsd:enumeration value="AdvancedTextPost"/>
+     <xsd:enumeration value="LinkPost"/>
+     <xsd:enumeration value="ContentPost"/>
+     <xsd:enumeration value="PollPost"/>
+     <xsd:enumeration value="RypplePost"/>
+     <xsd:enumeration value="ProfileSkillPost"/>
+     <xsd:enumeration value="DashboardComponentSnapshot"/>
+     <xsd:enumeration value="ApprovalPost"/>
+     <xsd:enumeration value="CaseCommentPost"/>
+     <xsd:enumeration value="ReplyPost"/>
+     <xsd:enumeration value="EmailMessageEvent"/>
+     <xsd:enumeration value="CallLogPost"/>
+     <xsd:enumeration value="ChangeStatusPost"/>
+     <xsd:enumeration value="AttachArticleEvent"/>
+     <xsd:enumeration value="MilestoneEvent"/>
+     <xsd:enumeration value="ActivityEvent"/>
+     <xsd:enumeration value="ChatTranscriptPost"/>
+     <xsd:enumeration value="CollaborationGroupCreated"/>
+     <xsd:enumeration value="CollaborationGroupUnarchived"/>
+     <xsd:enumeration value="SocialPost"/>
+     <xsd:enumeration value="QuestionPost"/>
+     <xsd:enumeration value="FacebookPost"/>
+     <xsd:enumeration value="BasicTemplateFeedItem"/>
+     <xsd:enumeration value="CreateRecordEvent"/>
+     <xsd:enumeration value="CanvasPost"/>
+     <xsd:enumeration value="AnnouncementPost"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="EmailToCaseSettings">
+    <xsd:sequence>
+     <xsd:element name="enableEmailToCase" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableHtmlEmail" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableOnDemandEmailToCase" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableThreadIDInBody" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableThreadIDInSubject" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="notifyOwnerOnNewCaseEmail" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="overEmailLimitAction" minOccurs="0" type="tns:EmailToCaseOnFailureActionType"/>
+     <xsd:element name="preQuoteSignature" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="routingAddresses" minOccurs="0" maxOccurs="unbounded" type="tns:EmailToCaseRoutingAddress"/>
+     <xsd:element name="unauthorizedSenderAction" minOccurs="0" type="tns:EmailToCaseOnFailureActionType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="EmailToCaseOnFailureActionType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Bounce"/>
+     <xsd:enumeration value="Discard"/>
+     <xsd:enumeration value="Requeue"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="EmailToCaseRoutingAddress">
+    <xsd:sequence>
+     <xsd:element name="addressType" minOccurs="0" type="tns:EmailToCaseRoutingAddressType"/>
+     <xsd:element name="authorizedSenders" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="caseOrigin" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="caseOwner" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="caseOwnerType" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="casePriority" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="createTask" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="emailAddress" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="routingName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="saveEmailHeaders" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="taskStatus" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="EmailToCaseRoutingAddressType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="EmailToCase"/>
+     <xsd:enumeration value="Outlook"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="WebToCaseSettings">
+    <xsd:sequence>
+     <xsd:element name="caseOrigin" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="defaultResponseTemplate" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="enableWebToCase" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelLayout">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enabledChannels" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="layoutItems" minOccurs="0" maxOccurs="unbounded" type="tns:ChannelLayoutItem"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelLayoutItem">
+    <xsd:sequence>
+     <xsd:element name="field" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ChatterAnswersSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="emailFollowersOnBestAnswer" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="emailFollowersOnReply" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="emailOwnerOnPrivateReply" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="emailOwnerOnReply" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableAnswerViaEmail" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableChatterAnswers" type="xsd:boolean"/>
+       <xsd:element name="enableFacebookSSO" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableInlinePublisher" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableReputation" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableRichTextEditor" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="facebookAuthProvider" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="showInPortals" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Community">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="communityFeedPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="emailFooterDocument" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="emailHeaderDocument" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="emailNotificationUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="enableChatterAnswers" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enablePrivateQuestions" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="expertsGroup" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="portal" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="reputationLevels" minOccurs="0" type="tns:ReputationLevels"/>
+       <xsd:element name="showInPortal" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="site" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReputationLevels">
+    <xsd:sequence>
+     <xsd:element name="chatterAnswersReputationLevels" minOccurs="0" maxOccurs="unbounded" type="tns:ChatterAnswersReputationLevel"/>
+     <xsd:element name="ideaReputationLevels" minOccurs="0" maxOccurs="unbounded" type="tns:IdeaReputationLevel"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ChatterAnswersReputationLevel">
+    <xsd:sequence>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="value" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="IdeaReputationLevel">
+    <xsd:sequence>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="value" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CompactLayout">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanySettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="fiscalYear" minOccurs="0" type="tns:FiscalYearSettings"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FiscalYearSettings">
+    <xsd:sequence>
+     <xsd:element name="fiscalYearNameBasedOn" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="startMonth" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConnectedApp">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="attributes" minOccurs="0" maxOccurs="unbounded" type="tns:ConnectedAppAttribute"/>
+       <xsd:element name="canvasConfig" minOccurs="0" type="tns:ConnectedAppCanvasConfig"/>
+       <xsd:element name="contactEmail" type="xsd:string"/>
+       <xsd:element name="contactPhone" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="iconUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="infoUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="ipRanges" minOccurs="0" maxOccurs="unbounded" type="tns:ConnectedAppIpRange"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="logoUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="mobileAppConfig" minOccurs="0" type="tns:ConnectedAppMobileDetailConfig"/>
+       <xsd:element name="mobileStartUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="oauthConfig" minOccurs="0" type="tns:ConnectedAppOauthConfig"/>
+       <xsd:element name="samlConfig" minOccurs="0" type="tns:ConnectedAppSamlConfig"/>
+       <xsd:element name="startUrl" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConnectedAppAttribute">
+    <xsd:sequence>
+     <xsd:element name="formula" type="xsd:string"/>
+     <xsd:element name="key" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConnectedAppCanvasConfig">
+    <xsd:sequence>
+     <xsd:element name="accessMethod" type="tns:AccessMethod"/>
+     <xsd:element name="canvasUrl" type="xsd:string"/>
+     <xsd:element name="lifecycleClass" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="locations" minOccurs="0" maxOccurs="unbounded" type="tns:CanvasLocationOptions"/>
+     <xsd:element name="options" minOccurs="0" maxOccurs="unbounded" type="tns:CanvasOptions"/>
+     <xsd:element name="samlInitiationMethod" minOccurs="0" type="tns:SamlInitiationMethod"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="AccessMethod">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Get"/>
+     <xsd:enumeration value="Post"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="CanvasLocationOptions">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Chatter"/>
+     <xsd:enumeration value="UserProfile"/>
+     <xsd:enumeration value="Visualforce"/>
+     <xsd:enumeration value="Aura"/>
+     <xsd:enumeration value="Publisher"/>
+     <xsd:enumeration value="ChatterFeed"/>
+     <xsd:enumeration value="ServiceDesk"/>
+     <xsd:enumeration value="OpenCTI"/>
+     <xsd:enumeration value="AppLauncher"/>
+     <xsd:enumeration value="MobileNav"/>
+     <xsd:enumeration value="PageLayout"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="CanvasOptions">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="HideShare"/>
+     <xsd:enumeration value="HideHeader"/>
+     <xsd:enumeration value="PersonalEnabled"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="SamlInitiationMethod">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="IdpInitiated"/>
+     <xsd:enumeration value="SpInitiated"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ConnectedAppIpRange">
+    <xsd:sequence>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="end" type="xsd:string"/>
+     <xsd:element name="start" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConnectedAppMobileDetailConfig">
+    <xsd:sequence>
+     <xsd:element name="applicationBinaryFile" minOccurs="0" type="xsd:base64Binary"/>
+     <xsd:element name="applicationBinaryFileName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="applicationBundleIdentifier" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="applicationFileLength" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="applicationIconFile" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="applicationIconFileName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="applicationInstallUrl" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="devicePlatform" type="tns:DevicePlatformType"/>
+     <xsd:element name="deviceType" minOccurs="0" type="tns:DeviceType"/>
+     <xsd:element name="minimumOsVersion" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="privateApp" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="version" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="DevicePlatformType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="ios"/>
+     <xsd:enumeration value="android"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="DeviceType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="phone"/>
+     <xsd:enumeration value="tablet"/>
+     <xsd:enumeration value="minitablet"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ConnectedAppOauthConfig">
+    <xsd:sequence>
+     <xsd:element name="callbackUrl" type="xsd:string"/>
+     <xsd:element name="certificate" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="consumerKey" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="consumerSecret" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="scopes" minOccurs="0" maxOccurs="unbounded" type="tns:ConnectedAppOauthAccessScope"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ConnectedAppOauthAccessScope">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Basic"/>
+     <xsd:enumeration value="Api"/>
+     <xsd:enumeration value="Web"/>
+     <xsd:enumeration value="Full"/>
+     <xsd:enumeration value="Chatter"/>
+     <xsd:enumeration value="CustomApplications"/>
+     <xsd:enumeration value="RefreshToken"/>
+     <xsd:enumeration value="OpenID"/>
+     <xsd:enumeration value="Profile"/>
+     <xsd:enumeration value="Email"/>
+     <xsd:enumeration value="Address"/>
+     <xsd:enumeration value="Phone"/>
+     <xsd:enumeration value="OfflineAccess"/>
+     <xsd:enumeration value="CustomPermissions"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ConnectedAppSamlConfig">
+    <xsd:sequence>
+     <xsd:element name="acsUrl" type="xsd:string"/>
+     <xsd:element name="certificate" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="encryptionCertificate" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="encryptionType" minOccurs="0" type="tns:SamlEncryptionType"/>
+     <xsd:element name="entityUrl" type="xsd:string"/>
+     <xsd:element name="issuer" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="samlNameIdFormat" minOccurs="0" type="tns:SamlNameIdFormatType"/>
+     <xsd:element name="samlSubjectCustomAttr" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="samlSubjectType" type="tns:SamlSubjectType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="SamlEncryptionType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AES_128"/>
+     <xsd:enumeration value="AES_256"/>
+     <xsd:enumeration value="Triple_Des"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="SamlNameIdFormatType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Unspecified"/>
+     <xsd:enumeration value="EmailAddress"/>
+     <xsd:enumeration value="Persistent"/>
+     <xsd:enumeration value="Transient"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="SamlSubjectType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Username"/>
+     <xsd:enumeration value="FederationId"/>
+     <xsd:enumeration value="UserId"/>
+     <xsd:enumeration value="SpokeId"/>
+     <xsd:enumeration value="CustomAttribute"/>
+     <xsd:enumeration value="PersistentId"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ContractSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="autoCalculateEndDate" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="autoExpirationDelay" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="autoExpirationRecipient" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="autoExpireContracts" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableContractHistoryTracking" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="notifyOwnersOnContractExpiration" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorsWhitelistOrigin">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="urlPattern" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomApplication">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="customApplicationComponents" minOccurs="0" type="tns:CustomApplicationComponents"/>
+       <xsd:element name="defaultLandingTab" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="detailPageRefreshMethod" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="domainWhitelist" minOccurs="0" type="tns:DomainWhitelist"/>
+       <xsd:element name="enableCustomizeMyTabs" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableKeyboardShortcuts" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableMultiMonitorComponents" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enablePinTabs" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="isServiceCloudConsole" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="keyboardShortcuts" minOccurs="0" type="tns:KeyboardShortcuts"/>
+       <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="listPlacement" minOccurs="0" type="tns:ListPlacement"/>
+       <xsd:element name="listRefreshMethod" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="liveAgentConfig" minOccurs="0" type="tns:LiveAgentConfig"/>
+       <xsd:element name="logo" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="pushNotifications" minOccurs="0" type="tns:PushNotifications"/>
+       <xsd:element name="saveUserSessions" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="tab" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="workspaceMappings" minOccurs="0" type="tns:WorkspaceMappings"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomApplicationComponents">
+    <xsd:sequence>
+     <xsd:element name="alignment" type="xsd:string"/>
+     <xsd:element name="customApplicationComponent" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DomainWhitelist">
+    <xsd:sequence>
+     <xsd:element name="domain" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="KeyboardShortcuts">
+    <xsd:sequence>
+     <xsd:element name="customShortcut" minOccurs="0" maxOccurs="unbounded" type="tns:CustomShortcut"/>
+     <xsd:element name="defaultShortcut" minOccurs="0" maxOccurs="unbounded" type="tns:DefaultShortcut"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomShortcut">
+    <xsd:complexContent>
+     <xsd:extension base="tns:DefaultShortcut">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="eventName" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="DefaultShortcut">
+    <xsd:sequence>
+     <xsd:element name="action" type="xsd:string"/>
+     <xsd:element name="active" type="xsd:boolean"/>
+     <xsd:element name="keyCommand" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ListPlacement">
+    <xsd:sequence>
+     <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="location" type="xsd:string"/>
+     <xsd:element name="units" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="width" minOccurs="0" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LiveAgentConfig">
+    <xsd:sequence>
+     <xsd:element name="enableLiveChat" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="openNewAccountSubtab" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="openNewCaseSubtab" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="openNewContactSubtab" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="openNewLeadSubtab" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="openNewVFPageSubtab" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="pagesToOpen" minOccurs="0" type="tns:PagesToOpen"/>
+     <xsd:element name="showKnowledgeArticles" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PagesToOpen">
+    <xsd:sequence>
+     <xsd:element name="pageToOpen" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PushNotifications">
+    <xsd:sequence>
+     <xsd:element name="pushNotification" minOccurs="0" maxOccurs="unbounded" type="tns:PushNotification"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PushNotification">
+    <xsd:sequence>
+     <xsd:element name="fieldNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="objectName" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WorkspaceMappings">
+    <xsd:sequence>
+     <xsd:element name="mapping" minOccurs="0" maxOccurs="unbounded" type="tns:WorkspaceMapping"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WorkspaceMapping">
+    <xsd:sequence>
+     <xsd:element name="fieldName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="tab" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomApplicationComponent">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="buttonIconUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="buttonStyle" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="buttonText" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="buttonWidth" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="isHeightFixed" type="xsd:boolean"/>
+       <xsd:element name="isHidden" type="xsd:boolean"/>
+       <xsd:element name="isWidthFixed" type="xsd:boolean"/>
+       <xsd:element name="visualforcePage" type="xsd:string"/>
+       <xsd:element name="width" minOccurs="0" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomDataType">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="customDataTypeComponents" minOccurs="0" maxOccurs="unbounded" type="tns:CustomDataTypeComponent"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="displayFormula" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="editComponentsOnSeparateLines" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="rightAligned" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="supportComponentsInReports" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomDataTypeComponent">
+    <xsd:sequence>
+     <xsd:element name="developerSuffix" type="xsd:string"/>
+     <xsd:element name="enforceFieldRequiredness" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="length" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="precision" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="scale" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="sortOrder" minOccurs="0" type="tns:SortOrder"/>
+     <xsd:element name="sortPriority" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="type" type="tns:FieldType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="SortOrder">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Asc"/>
+     <xsd:enumeration value="Desc"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="FieldType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AutoNumber"/>
+     <xsd:enumeration value="Lookup"/>
+     <xsd:enumeration value="MasterDetail"/>
+     <xsd:enumeration value="Checkbox"/>
+     <xsd:enumeration value="Currency"/>
+     <xsd:enumeration value="Date"/>
+     <xsd:enumeration value="DateTime"/>
+     <xsd:enumeration value="Email"/>
+     <xsd:enumeration value="Number"/>
+     <xsd:enumeration value="Percent"/>
+     <xsd:enumeration value="Phone"/>
+     <xsd:enumeration value="Picklist"/>
+     <xsd:enumeration value="MultiselectPicklist"/>
+     <xsd:enumeration value="Text"/>
+     <xsd:enumeration value="TextArea"/>
+     <xsd:enumeration value="LongTextArea"/>
+     <xsd:enumeration value="Html"/>
+     <xsd:enumeration value="Url"/>
+     <xsd:enumeration value="EncryptedText"/>
+     <xsd:enumeration value="Summary"/>
+     <xsd:enumeration value="Hierarchy"/>
+     <xsd:enumeration value="File"/>
+     <xsd:enumeration value="ExternalLookup"/>
+     <xsd:enumeration value="IndirectLookup"/>
+     <xsd:enumeration value="CustomDataType"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CustomField">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="caseSensitive" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="customDataType" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultValue" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="deleteConstraint" minOccurs="0" type="tns:DeleteConstraint"/>
+       <xsd:element name="deprecated" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="displayFormat" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="encrypted" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="escapeMarkup" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="externalDeveloperName" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="externalId" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="formula" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="formulaTreatBlanksAs" minOccurs="0" type="tns:TreatBlanksAs"/>
+       <xsd:element name="inlineHelpText" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="isFilteringDisabled" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="isNameField" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="isSortingDisabled" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="length" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="lookupFilter" minOccurs="0" type="tns:LookupFilter"/>
+       <xsd:element name="maskChar" minOccurs="0" type="tns:EncryptedFieldMaskChar"/>
+       <xsd:element name="maskType" minOccurs="0" type="tns:EncryptedFieldMaskType"/>
+       <xsd:element name="picklist" minOccurs="0" type="tns:Picklist"/>
+       <xsd:element name="populateExistingRows" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="precision" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="referenceTargetField" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="referenceTo" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="relationshipLabel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="relationshipName" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="relationshipOrder" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="reparentableMasterDetail" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="required" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="restrictedAdminField" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="scale" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="startingNumber" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="stripMarkup" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="summarizedField" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="summaryFilterItems" minOccurs="0" maxOccurs="unbounded" type="tns:FilterItem"/>
+       <xsd:element name="summaryForeignKey" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="summaryOperation" minOccurs="0" type="tns:SummaryOperations"/>
+       <xsd:element name="trackFeedHistory" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="trackHistory" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="trackTrending" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="type" minOccurs="0" type="tns:FieldType"/>
+       <xsd:element name="unique" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="visibleLines" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="writeRequiresMasterRead" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="DeleteConstraint">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Cascade"/>
+     <xsd:enumeration value="Restrict"/>
+     <xsd:enumeration value="SetNull"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="TreatBlanksAs">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="BlankAsBlank"/>
+     <xsd:enumeration value="BlankAsZero"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="LookupFilter">
+    <xsd:sequence>
+     <xsd:element name="active" type="xsd:boolean"/>
+     <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="errorMessage" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="filterItems" minOccurs="0" maxOccurs="unbounded" type="tns:FilterItem"/>
+     <xsd:element name="infoMessage" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="isOptional" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="EncryptedFieldMaskChar">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="asterisk"/>
+     <xsd:enumeration value="X"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="EncryptedFieldMaskType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="all"/>
+     <xsd:enumeration value="creditCard"/>
+     <xsd:enumeration value="ssn"/>
+     <xsd:enumeration value="lastFour"/>
+     <xsd:enumeration value="sin"/>
+     <xsd:enumeration value="nino"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="Picklist">
+    <xsd:sequence>
+     <xsd:element name="controllingField" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="picklistValues" minOccurs="0" maxOccurs="unbounded" type="tns:PicklistValue"/>
+     <xsd:element name="sorted" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="SummaryOperations">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="count"/>
+     <xsd:enumeration value="sum"/>
+     <xsd:enumeration value="min"/>
+     <xsd:enumeration value="max"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CustomLabel">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="categories" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="language" type="xsd:string"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+       <xsd:element name="shortDescription" type="xsd:string"/>
+       <xsd:element name="value" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomLabels">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="labels" minOccurs="0" maxOccurs="unbounded" type="tns:CustomLabel"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomMetadata">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="values" minOccurs="0" maxOccurs="unbounded" type="tns:CustomMetadataValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomMetadataValue">
+    <xsd:sequence>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="value" type="xsd:anyType" nillable="true"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomObject">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="actionOverrides" minOccurs="0" maxOccurs="unbounded" type="tns:ActionOverride"/>
+       <xsd:element name="allowInChatterGroups" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="articleTypeChannelDisplay" minOccurs="0" type="tns:ArticleTypeChannelDisplay"/>
+       <xsd:element name="businessProcesses" minOccurs="0" maxOccurs="unbounded" type="tns:BusinessProcess"/>
+       <xsd:element name="compactLayoutAssignment" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="compactLayouts" minOccurs="0" maxOccurs="unbounded" type="tns:CompactLayout"/>
+       <xsd:element name="customHelp" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="customHelpPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="customSettingsType" minOccurs="0" type="tns:CustomSettingsType"/>
+       <xsd:element name="deploymentStatus" minOccurs="0" type="tns:DeploymentStatus"/>
+       <xsd:element name="deprecated" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="enableActivities" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableBulkApi" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableDivisions" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableEnhancedLookup" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableFeeds" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableHistory" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableReports" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSharing" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableStreamingApi" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="externalDataSource" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="externalName" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="externalRepository" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="externalSharingModel" minOccurs="0" type="tns:SharingModel"/>
+       <xsd:element name="fieldSets" minOccurs="0" maxOccurs="unbounded" type="tns:FieldSet"/>
+       <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="tns:CustomField"/>
+       <xsd:element name="gender" minOccurs="0" type="tns:Gender"/>
+       <xsd:element name="historyRetentionPolicy" minOccurs="0" type="tns:HistoryRetentionPolicy"/>
+       <xsd:element name="household" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="listViews" minOccurs="0" maxOccurs="unbounded" type="tns:ListView"/>
+       <xsd:element name="nameField" minOccurs="0" type="tns:CustomField"/>
+       <xsd:element name="pluralLabel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="recordTypeTrackFeedHistory" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="recordTypeTrackHistory" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="recordTypes" minOccurs="0" maxOccurs="unbounded" type="tns:RecordType"/>
+       <xsd:element name="searchLayouts" minOccurs="0" type="tns:SearchLayouts"/>
+       <xsd:element name="sharingModel" minOccurs="0" type="tns:SharingModel"/>
+       <xsd:element name="sharingReasons" minOccurs="0" maxOccurs="unbounded" type="tns:SharingReason"/>
+       <xsd:element name="sharingRecalculations" minOccurs="0" maxOccurs="unbounded" type="tns:SharingRecalculation"/>
+       <xsd:element name="startsWith" minOccurs="0" type="tns:StartsWith"/>
+       <xsd:element name="validationRules" minOccurs="0" maxOccurs="unbounded" type="tns:ValidationRule"/>
+       <xsd:element name="visibility" minOccurs="0" type="tns:SetupObjectVisibility"/>
+       <xsd:element name="webLinks" minOccurs="0" maxOccurs="unbounded" type="tns:WebLink"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActionOverride">
+    <xsd:sequence>
+     <xsd:element name="actionName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="comment" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="content" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="skipRecordTypeSelect" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="type" minOccurs="0" type="tns:ActionOverrideType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ActionOverrideType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Default"/>
+     <xsd:enumeration value="Standard"/>
+     <xsd:enumeration value="Scontrol"/>
+     <xsd:enumeration value="Visualforce"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ArticleTypeChannelDisplay">
+    <xsd:sequence>
+     <xsd:element name="articleTypeTemplates" minOccurs="0" maxOccurs="unbounded" type="tns:ArticleTypeTemplate"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ArticleTypeTemplate">
+    <xsd:sequence>
+     <xsd:element name="channel" type="tns:Channel"/>
+     <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="template" type="tns:Template"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="Channel">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AllChannels"/>
+     <xsd:enumeration value="App"/>
+     <xsd:enumeration value="Pkb"/>
+     <xsd:enumeration value="Csp"/>
+     <xsd:enumeration value="Prm"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="Template">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Page"/>
+     <xsd:enumeration value="Tab"/>
+     <xsd:enumeration value="Toc"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="CustomSettingsType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="List"/>
+     <xsd:enumeration value="Hierarchy"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="DeploymentStatus">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="InDevelopment"/>
+     <xsd:enumeration value="Deployed"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="SharingModel">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Private"/>
+     <xsd:enumeration value="Read"/>
+     <xsd:enumeration value="ReadSelect"/>
+     <xsd:enumeration value="ReadWrite"/>
+     <xsd:enumeration value="ReadWriteTransfer"/>
+     <xsd:enumeration value="FullAccess"/>
+     <xsd:enumeration value="ControlledByParent"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FieldSet">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="availableFields" minOccurs="0" maxOccurs="unbounded" type="tns:FieldSetItem"/>
+       <xsd:element name="description" type="xsd:string"/>
+       <xsd:element name="displayedFields" minOccurs="0" maxOccurs="unbounded" type="tns:FieldSetItem"/>
+       <xsd:element name="label" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FieldSetItem">
+    <xsd:sequence>
+     <xsd:element name="field" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="isFieldManaged" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="isRequired" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="Gender">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Neuter"/>
+     <xsd:enumeration value="Masculine"/>
+     <xsd:enumeration value="Feminine"/>
+     <xsd:enumeration value="AnimateMasculine"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="HistoryRetentionPolicy">
+    <xsd:sequence>
+     <xsd:element name="archiveAfterMonths" type="xsd:int"/>
+     <xsd:element name="archiveRetentionYears" type="xsd:int"/>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ListView">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="columns" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="division" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="filterScope" type="tns:FilterScope"/>
+       <xsd:element name="filters" minOccurs="0" maxOccurs="unbounded" type="tns:ListViewFilter"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="language" minOccurs="0" type="tns:Language"/>
+       <xsd:element name="queue" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="sharedTo" minOccurs="0" type="tns:SharedTo"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="FilterScope">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Everything"/>
+     <xsd:enumeration value="Mine"/>
+     <xsd:enumeration value="Queue"/>
+     <xsd:enumeration value="Delegated"/>
+     <xsd:enumeration value="MyTerritory"/>
+     <xsd:enumeration value="MyTeamTerritory"/>
+     <xsd:enumeration value="Team"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ListViewFilter">
+    <xsd:sequence>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="operation" type="tns:FilterOperation"/>
+     <xsd:element name="value" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="Language">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="en_US"/>
+     <xsd:enumeration value="de"/>
+     <xsd:enumeration value="es"/>
+     <xsd:enumeration value="fr"/>
+     <xsd:enumeration value="it"/>
+     <xsd:enumeration value="ja"/>
+     <xsd:enumeration value="sv"/>
+     <xsd:enumeration value="ko"/>
+     <xsd:enumeration value="zh_TW"/>
+     <xsd:enumeration value="zh_CN"/>
+     <xsd:enumeration value="pt_BR"/>
+     <xsd:enumeration value="nl_NL"/>
+     <xsd:enumeration value="da"/>
+     <xsd:enumeration value="th"/>
+     <xsd:enumeration value="fi"/>
+     <xsd:enumeration value="ru"/>
+     <xsd:enumeration value="es_MX"/>
+     <xsd:enumeration value="no"/>
+     <xsd:enumeration value="hu"/>
+     <xsd:enumeration value="pl"/>
+     <xsd:enumeration value="cs"/>
+     <xsd:enumeration value="tr"/>
+     <xsd:enumeration value="in"/>
+     <xsd:enumeration value="ro"/>
+     <xsd:enumeration value="vi"/>
+     <xsd:enumeration value="uk"/>
+     <xsd:enumeration value="iw"/>
+     <xsd:enumeration value="el"/>
+     <xsd:enumeration value="bg"/>
+     <xsd:enumeration value="en_GB"/>
+     <xsd:enumeration value="ar"/>
+     <xsd:enumeration value="sk"/>
+     <xsd:enumeration value="pt_PT"/>
+     <xsd:enumeration value="hr"/>
+     <xsd:enumeration value="sl"/>
+     <xsd:enumeration value="fr_CA"/>
+     <xsd:enumeration value="ka"/>
+     <xsd:enumeration value="sr"/>
+     <xsd:enumeration value="sh"/>
+     <xsd:enumeration value="en_AU"/>
+     <xsd:enumeration value="en_MY"/>
+     <xsd:enumeration value="en_IN"/>
+     <xsd:enumeration value="en_PH"/>
+     <xsd:enumeration value="en_CA"/>
+     <xsd:enumeration value="ro_MD"/>
+     <xsd:enumeration value="bs"/>
+     <xsd:enumeration value="mk"/>
+     <xsd:enumeration value="lv"/>
+     <xsd:enumeration value="lt"/>
+     <xsd:enumeration value="et"/>
+     <xsd:enumeration value="sq"/>
+     <xsd:enumeration value="sh_ME"/>
+     <xsd:enumeration value="mt"/>
+     <xsd:enumeration value="ga"/>
+     <xsd:enumeration value="eu"/>
+     <xsd:enumeration value="cy"/>
+     <xsd:enumeration value="is"/>
+     <xsd:enumeration value="ms"/>
+     <xsd:enumeration value="tl"/>
+     <xsd:enumeration value="lb"/>
+     <xsd:enumeration value="rm"/>
+     <xsd:enumeration value="hy"/>
+     <xsd:enumeration value="hi"/>
+     <xsd:enumeration value="ur"/>
+     <xsd:enumeration value="bn"/>
+     <xsd:enumeration value="de_AT"/>
+     <xsd:enumeration value="de_CH"/>
+     <xsd:enumeration value="ta"/>
+     <xsd:enumeration value="ar_DZ"/>
+     <xsd:enumeration value="ar_BH"/>
+     <xsd:enumeration value="ar_EG"/>
+     <xsd:enumeration value="ar_IQ"/>
+     <xsd:enumeration value="ar_JO"/>
+     <xsd:enumeration value="ar_KW"/>
+     <xsd:enumeration value="ar_LB"/>
+     <xsd:enumeration value="ar_LY"/>
+     <xsd:enumeration value="ar_MA"/>
+     <xsd:enumeration value="ar_OM"/>
+     <xsd:enumeration value="ar_QA"/>
+     <xsd:enumeration value="ar_SA"/>
+     <xsd:enumeration value="ar_SD"/>
+     <xsd:enumeration value="ar_SY"/>
+     <xsd:enumeration value="ar_TN"/>
+     <xsd:enumeration value="ar_AE"/>
+     <xsd:enumeration value="ar_YE"/>
+     <xsd:enumeration value="zh_SG"/>
+     <xsd:enumeration value="zh_HK"/>
+     <xsd:enumeration value="en_HK"/>
+     <xsd:enumeration value="en_IE"/>
+     <xsd:enumeration value="en_SG"/>
+     <xsd:enumeration value="en_ZA"/>
+     <xsd:enumeration value="fr_BE"/>
+     <xsd:enumeration value="fr_LU"/>
+     <xsd:enumeration value="fr_CH"/>
+     <xsd:enumeration value="de_LU"/>
+     <xsd:enumeration value="it_CH"/>
+     <xsd:enumeration value="es_AR"/>
+     <xsd:enumeration value="es_BO"/>
+     <xsd:enumeration value="es_CL"/>
+     <xsd:enumeration value="es_CO"/>
+     <xsd:enumeration value="es_CR"/>
+     <xsd:enumeration value="es_DO"/>
+     <xsd:enumeration value="es_EC"/>
+     <xsd:enumeration value="es_SV"/>
+     <xsd:enumeration value="es_GT"/>
+     <xsd:enumeration value="es_HN"/>
+     <xsd:enumeration value="es_NI"/>
+     <xsd:enumeration value="es_PA"/>
+     <xsd:enumeration value="es_PY"/>
+     <xsd:enumeration value="es_PE"/>
+     <xsd:enumeration value="es_PR"/>
+     <xsd:enumeration value="es_US"/>
+     <xsd:enumeration value="es_UY"/>
+     <xsd:enumeration value="es_VE"/>
+     <xsd:enumeration value="eo"/>
+     <xsd:enumeration value="iw_EO"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="SharedTo">
+    <xsd:sequence>
+     <xsd:element name="allCustomerPortalUsers" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="allInternalUsers" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="allPartnerUsers" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="group" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="groups" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="managerSubordinates" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="managers" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="portalRole" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="portalRoleAndSubordinates" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="queue" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="role" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="roleAndSubordinates" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="roleAndSubordinatesInternal" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="roles" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="rolesAndSubordinates" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="territories" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="territoriesAndSubordinates" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="territory" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="territoryAndSubordinates" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RecordType">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="businessProcess" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="compactLayoutAssignment" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="picklistValues" minOccurs="0" maxOccurs="unbounded" type="tns:RecordTypePicklistValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="RecordTypePicklistValue">
+    <xsd:sequence>
+     <xsd:element name="picklist" type="xsd:string"/>
+     <xsd:element name="values" minOccurs="0" maxOccurs="unbounded" type="tns:PicklistValue"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SearchLayouts">
+    <xsd:sequence>
+     <xsd:element name="customTabListAdditionalFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="excludedStandardButtons" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="listViewButtons" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="lookupDialogsAdditionalFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="lookupFilterFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="lookupPhoneDialogsAdditionalFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="searchFilterFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="searchResultsAdditionalFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="searchResultsCustomButtons" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SharingReason">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="label" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="SharingRecalculation">
+    <xsd:sequence>
+     <xsd:element name="className" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="StartsWith">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Consonant"/>
+     <xsd:enumeration value="Vowel"/>
+     <xsd:enumeration value="Special"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ValidationRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="errorConditionFormula" type="xsd:string"/>
+       <xsd:element name="errorDisplayField" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="errorMessage" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="SetupObjectVisibility">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Protected"/>
+     <xsd:enumeration value="Public"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="WebLink">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="availability" type="tns:WebLinkAvailability"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="displayType" type="tns:WebLinkDisplayType"/>
+       <xsd:element name="encodingKey" minOccurs="0" type="tns:Encoding"/>
+       <xsd:element name="hasMenubar" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="hasScrollbars" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="hasToolbar" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="isResizable" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="linkType" type="tns:WebLinkType"/>
+       <xsd:element name="masterLabel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="openType" type="tns:WebLinkWindowType"/>
+       <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="position" minOccurs="0" type="tns:WebLinkPosition"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+       <xsd:element name="requireRowSelection" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="scontrol" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="showsLocation" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showsStatus" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="url" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="width" minOccurs="0" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="WebLinkAvailability">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="online"/>
+     <xsd:enumeration value="offline"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="WebLinkDisplayType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="link"/>
+     <xsd:enumeration value="button"/>
+     <xsd:enumeration value="massActionButton"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="Encoding">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="UTF-8"/>
+     <xsd:enumeration value="ISO-8859-1"/>
+     <xsd:enumeration value="Shift_JIS"/>
+     <xsd:enumeration value="ISO-2022-JP"/>
+     <xsd:enumeration value="EUC-JP"/>
+     <xsd:enumeration value="ks_c_5601-1987"/>
+     <xsd:enumeration value="Big5"/>
+     <xsd:enumeration value="GB2312"/>
+     <xsd:enumeration value="Big5-HKSCS"/>
+     <xsd:enumeration value="x-SJIS_0213"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="WebLinkType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="url"/>
+     <xsd:enumeration value="sControl"/>
+     <xsd:enumeration value="javascript"/>
+     <xsd:enumeration value="page"/>
+     <xsd:enumeration value="flow"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="WebLinkWindowType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="newWindow"/>
+     <xsd:enumeration value="sidebar"/>
+     <xsd:enumeration value="noSidebar"/>
+     <xsd:enumeration value="replace"/>
+     <xsd:enumeration value="onClickJavaScript"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="WebLinkPosition">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="fullScreen"/>
+     <xsd:enumeration value="none"/>
+     <xsd:enumeration value="topLeft"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CustomObjectTranslation">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="caseValues" minOccurs="0" maxOccurs="unbounded" type="tns:ObjectNameCaseValue"/>
+       <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="tns:CustomFieldTranslation"/>
+       <xsd:element name="gender" minOccurs="0" type="tns:Gender"/>
+       <xsd:element name="layouts" minOccurs="0" maxOccurs="unbounded" type="tns:LayoutTranslation"/>
+       <xsd:element name="nameFieldLabel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="quickActions" minOccurs="0" maxOccurs="unbounded" type="tns:QuickActionTranslation"/>
+       <xsd:element name="recordTypes" minOccurs="0" maxOccurs="unbounded" type="tns:RecordTypeTranslation"/>
+       <xsd:element name="sharingReasons" minOccurs="0" maxOccurs="unbounded" type="tns:SharingReasonTranslation"/>
+       <xsd:element name="standardFields" minOccurs="0" maxOccurs="unbounded" type="tns:StandardFieldTranslation"/>
+       <xsd:element name="startsWith" minOccurs="0" type="tns:StartsWith"/>
+       <xsd:element name="validationRules" minOccurs="0" maxOccurs="unbounded" type="tns:ValidationRuleTranslation"/>
+       <xsd:element name="webLinks" minOccurs="0" maxOccurs="unbounded" type="tns:WebLinkTranslation"/>
+       <xsd:element name="workflowTasks" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowTaskTranslation"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ObjectNameCaseValue">
+    <xsd:sequence>
+     <xsd:element name="article" minOccurs="0" type="tns:Article"/>
+     <xsd:element name="caseType" minOccurs="0" type="tns:CaseType"/>
+     <xsd:element name="plural" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="possessive" minOccurs="0" type="tns:Possessive"/>
+     <xsd:element name="value" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="Article">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Indefinite"/>
+     <xsd:enumeration value="Definite"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="CaseType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Nominative"/>
+     <xsd:enumeration value="Accusative"/>
+     <xsd:enumeration value="Genitive"/>
+     <xsd:enumeration value="Dative"/>
+     <xsd:enumeration value="Inessive"/>
+     <xsd:enumeration value="Elative"/>
+     <xsd:enumeration value="Illative"/>
+     <xsd:enumeration value="Adessive"/>
+     <xsd:enumeration value="Ablative"/>
+     <xsd:enumeration value="Allative"/>
+     <xsd:enumeration value="Essive"/>
+     <xsd:enumeration value="Translative"/>
+     <xsd:enumeration value="Partitive"/>
+     <xsd:enumeration value="Objective"/>
+     <xsd:enumeration value="Subjective"/>
+     <xsd:enumeration value="Instrumental"/>
+     <xsd:enumeration value="Prepositional"/>
+     <xsd:enumeration value="Locative"/>
+     <xsd:enumeration value="Vocative"/>
+     <xsd:enumeration value="Sublative"/>
+     <xsd:enumeration value="Superessive"/>
+     <xsd:enumeration value="Delative"/>
+     <xsd:enumeration value="Causalfinal"/>
+     <xsd:enumeration value="Essiveformal"/>
+     <xsd:enumeration value="Termanative"/>
+     <xsd:enumeration value="Distributive"/>
+     <xsd:enumeration value="Ergative"/>
+     <xsd:enumeration value="Adverbial"/>
+     <xsd:enumeration value="Abessive"/>
+     <xsd:enumeration value="Comitative"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="Possessive">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="First"/>
+     <xsd:enumeration value="Second"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CustomFieldTranslation">
+    <xsd:sequence>
+     <xsd:element name="caseValues" minOccurs="0" maxOccurs="unbounded" type="tns:ObjectNameCaseValue"/>
+     <xsd:element name="gender" minOccurs="0" type="tns:Gender"/>
+     <xsd:element name="help" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="lookupFilter" minOccurs="0" type="tns:LookupFilterTranslation"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="picklistValues" minOccurs="0" maxOccurs="unbounded" type="tns:PicklistValueTranslation"/>
+     <xsd:element name="relationshipLabel" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="startsWith" minOccurs="0" type="tns:StartsWith"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LookupFilterTranslation">
+    <xsd:sequence>
+     <xsd:element name="errorMessage" type="xsd:string"/>
+     <xsd:element name="informationalMessage" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PicklistValueTranslation">
+    <xsd:sequence>
+     <xsd:element name="masterLabel" type="xsd:string"/>
+     <xsd:element name="translation" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LayoutTranslation">
+    <xsd:sequence>
+     <xsd:element name="layout" type="xsd:string"/>
+     <xsd:element name="layoutType" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="sections" minOccurs="0" maxOccurs="unbounded" type="tns:LayoutSectionTranslation"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LayoutSectionTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="section" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuickActionTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RecordTypeTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SharingReasonTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StandardFieldTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationRuleTranslation">
+    <xsd:sequence>
+     <xsd:element name="errorMessage" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WebLinkTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WorkflowTaskTranslation">
+    <xsd:sequence>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="subject" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomPageWebLink">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="availability" type="tns:WebLinkAvailability"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="displayType" type="tns:WebLinkDisplayType"/>
+       <xsd:element name="encodingKey" minOccurs="0" type="tns:Encoding"/>
+       <xsd:element name="hasMenubar" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="hasScrollbars" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="hasToolbar" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="isResizable" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="linkType" type="tns:WebLinkType"/>
+       <xsd:element name="masterLabel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="openType" type="tns:WebLinkWindowType"/>
+       <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="position" minOccurs="0" type="tns:WebLinkPosition"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+       <xsd:element name="requireRowSelection" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="scontrol" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="showsLocation" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showsStatus" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="url" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="width" minOccurs="0" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomPermission">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="connectedApp" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="requiredPermission" minOccurs="0" maxOccurs="unbounded" type="tns:CustomPermissionDependencyRequired"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomPermissionDependencyRequired">
+    <xsd:sequence>
+     <xsd:element name="customPermission" type="xsd:string"/>
+     <xsd:element name="dependency" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomSite">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="allowHomePage" type="xsd:boolean"/>
+       <xsd:element name="allowStandardAnswersPages" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="allowStandardIdeasPages" type="xsd:boolean"/>
+       <xsd:element name="allowStandardLookups" type="xsd:boolean"/>
+       <xsd:element name="allowStandardSearch" type="xsd:boolean"/>
+       <xsd:element name="analyticsTrackingCode" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="authorizationRequiredPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="bandwidthExceededPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="changePasswordPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="chatterAnswersForgotPasswordConfirmPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="chatterAnswersForgotPasswordPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="chatterAnswersHelpPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="chatterAnswersLoginPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="chatterAnswersRegistrationPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="clickjackProtectionLevel" type="tns:SiteClickjackProtectionLevel"/>
+       <xsd:element name="customWebAddresses" minOccurs="0" maxOccurs="unbounded" type="tns:SiteWebAddress"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="favoriteIcon" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="fileNotFoundPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="forgotPasswordPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="genericErrorPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="guestProfile" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="inMaintenancePage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="inactiveIndexPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="indexPage" type="xsd:string"/>
+       <xsd:element name="masterLabel" type="xsd:string"/>
+       <xsd:element name="myProfilePage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="portal" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="requireHttps" type="xsd:boolean"/>
+       <xsd:element name="requireInsecurePortalAccess" type="xsd:boolean"/>
+       <xsd:element name="robotsTxtPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="rootComponent" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="selfRegPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="serverIsDown" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="siteAdmin" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="siteRedirectMappings" minOccurs="0" maxOccurs="unbounded" type="tns:SiteRedirectMapping"/>
+       <xsd:element name="siteTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="siteType" type="tns:SiteType"/>
+       <xsd:element name="subdomain" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="urlPathPrefix" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="SiteClickjackProtectionLevel">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AllowAllFraming"/>
+     <xsd:enumeration value="SameOriginOnly"/>
+     <xsd:enumeration value="NoFraming"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="SiteWebAddress">
+    <xsd:sequence>
+     <xsd:element name="certificate" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="domainName" type="xsd:string"/>
+     <xsd:element name="primary" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SiteRedirectMapping">
+    <xsd:sequence>
+     <xsd:element name="action" type="tns:SiteRedirect"/>
+     <xsd:element name="isActive" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="source" type="xsd:string"/>
+     <xsd:element name="target" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="SiteRedirect">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Permanent"/>
+     <xsd:enumeration value="Temporary"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="SiteType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Siteforce"/>
+     <xsd:enumeration value="Visualforce"/>
+     <xsd:enumeration value="User"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="CustomTab">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="auraComponent" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="customObject" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="flexiPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="frameHeight" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="hasSidebar" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="icon" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="mobileReady" type="xsd:boolean"/>
+       <xsd:element name="motif" type="xsd:string"/>
+       <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="scontrol" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="splashPageLink" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="url" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="urlEncodingKey" minOccurs="0" type="tns:Encoding"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Dashboard">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="backgroundEndColor" type="xsd:string"/>
+       <xsd:element name="backgroundFadeDirection" type="tns:ChartBackgroundDirection"/>
+       <xsd:element name="backgroundStartColor" type="xsd:string"/>
+       <xsd:element name="dashboardFilters" minOccurs="0" maxOccurs="unbounded" type="tns:DashboardFilter"/>
+       <xsd:element name="dashboardResultRefreshedDate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="dashboardResultRunningUser" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="dashboardType" minOccurs="0" type="tns:DashboardType"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="leftSection" type="tns:DashboardComponentSection"/>
+       <xsd:element name="middleSection" minOccurs="0" type="tns:DashboardComponentSection"/>
+       <xsd:element name="rightSection" type="tns:DashboardComponentSection"/>
+       <xsd:element name="runningUser" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="textColor" type="xsd:string"/>
+       <xsd:element name="title" type="xsd:string"/>
+       <xsd:element name="titleColor" type="xsd:string"/>
+       <xsd:element name="titleSize" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="ChartBackgroundDirection">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="TopToBottom"/>
+     <xsd:enumeration value="LeftToRight"/>
+     <xsd:enumeration value="Diagonal"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="DashboardFilter">
+    <xsd:sequence>
+     <xsd:element name="dashboardFilterOptions" minOccurs="0" maxOccurs="unbounded" type="tns:DashboardFilterOption"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DashboardFilterOption">
+    <xsd:sequence>
+     <xsd:element name="operator" type="tns:DashboardFilterOperation"/>
+     <xsd:element name="values" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="DashboardFilterOperation">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="equals"/>
+     <xsd:enumeration value="notEqual"/>
+     <xsd:enumeration value="lessThan"/>
+     <xsd:enumeration value="greaterThan"/>
+     <xsd:enumeration value="lessOrEqual"/>
+     <xsd:enumeration value="greaterOrEqual"/>
+     <xsd:enumeration value="contains"/>
+     <xsd:enumeration value="notContain"/>
+     <xsd:enumeration value="startsWith"/>
+     <xsd:enumeration value="includes"/>
+     <xsd:enumeration value="excludes"/>
+     <xsd:enumeration value="between"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="DashboardType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="SpecifiedUser"/>
+     <xsd:enumeration value="LoggedInUser"/>
+     <xsd:enumeration value="MyTeamUser"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="DashboardComponentSection">
+    <xsd:sequence>
+     <xsd:element name="columnSize" type="tns:DashboardComponentSize"/>
+     <xsd:element name="components" minOccurs="0" maxOccurs="unbounded" type="tns:DashboardComponent"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="DashboardComponentSize">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Narrow"/>
+     <xsd:enumeration value="Medium"/>
+     <xsd:enumeration value="Wide"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="DashboardComponent">
+    <xsd:sequence>
+     <xsd:element name="autoselectColumnsFromReport" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="chartAxisRange" minOccurs="0" type="tns:ChartRangeType"/>
+     <xsd:element name="chartAxisRangeMax" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="chartAxisRangeMin" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="chartSummary" minOccurs="0" maxOccurs="unbounded" type="tns:ChartSummary"/>
+     <xsd:element name="componentType" type="tns:DashboardComponentType"/>
+     <xsd:element name="dashboardFilterColumns" minOccurs="0" maxOccurs="unbounded" type="tns:DashboardFilterColumn"/>
+     <xsd:element name="dashboardTableColumn" minOccurs="0" maxOccurs="unbounded" type="tns:DashboardTableColumn"/>
+     <xsd:element name="displayUnits" minOccurs="0" type="tns:ChartUnits"/>
+     <xsd:element name="drillDownUrl" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="drillEnabled" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="drillToDetailEnabled" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableHover" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="expandOthers" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="footer" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="gaugeMax" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="gaugeMin" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="groupingColumn" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="header" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="indicatorBreakpoint1" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="indicatorBreakpoint2" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="indicatorHighColor" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="indicatorLowColor" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="indicatorMiddleColor" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="legendPosition" minOccurs="0" type="tns:ChartLegendPosition"/>
+     <xsd:element name="maxValuesDisplayed" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="metricLabel" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="pageHeightInPixels" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="report" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="scontrol" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="scontrolHeightInPixels" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="showPercentage" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showPicturesOnCharts" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showPicturesOnTables" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showTotal" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showValues" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="sortBy" minOccurs="0" type="tns:DashboardComponentFilter"/>
+     <xsd:element name="title" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="useReportChart" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ChartRangeType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Auto"/>
+     <xsd:enumeration value="Manual"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ChartSummary">
+    <xsd:sequence>
+     <xsd:element name="aggregate" minOccurs="0" type="tns:ReportSummaryType"/>
+     <xsd:element name="axisBinding" minOccurs="0" type="tns:ChartAxis"/>
+     <xsd:element name="column" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ChartAxis">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="x"/>
+     <xsd:enumeration value="y"/>
+     <xsd:enumeration value="y2"/>
+     <xsd:enumeration value="r"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="DashboardComponentType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Bar"/>
+     <xsd:enumeration value="BarGrouped"/>
+     <xsd:enumeration value="BarStacked"/>
+     <xsd:enumeration value="BarStacked100"/>
+     <xsd:enumeration value="Column"/>
+     <xsd:enumeration value="ColumnGrouped"/>
+     <xsd:enumeration value="ColumnStacked"/>
+     <xsd:enumeration value="ColumnStacked100"/>
+     <xsd:enumeration value="Line"/>
+     <xsd:enumeration value="LineGrouped"/>
+     <xsd:enumeration value="Pie"/>
+     <xsd:enumeration value="Table"/>
+     <xsd:enumeration value="Metric"/>
+     <xsd:enumeration value="Gauge"/>
+     <xsd:enumeration value="LineCumulative"/>
+     <xsd:enumeration value="LineGroupedCumulative"/>
+     <xsd:enumeration value="Scontrol"/>
+     <xsd:enumeration value="VisualforcePage"/>
+     <xsd:enumeration value="Donut"/>
+     <xsd:enumeration value="Funnel"/>
+     <xsd:enumeration value="ColumnLine"/>
+     <xsd:enumeration value="ColumnLineGrouped"/>
+     <xsd:enumeration value="ColumnLineStacked"/>
+     <xsd:enumeration value="ColumnLineStacked100"/>
+     <xsd:enumeration value="Scatter"/>
+     <xsd:enumeration value="ScatterGrouped"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="DashboardFilterColumn">
+    <xsd:sequence>
+     <xsd:element name="column" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DashboardTableColumn">
+    <xsd:sequence>
+     <xsd:element name="aggregateType" minOccurs="0" type="tns:ReportSummaryType"/>
+     <xsd:element name="calculatePercent" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="column" type="xsd:string"/>
+     <xsd:element name="decimalPlaces" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="showTotal" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="sortBy" minOccurs="0" type="tns:DashboardComponentFilter"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="DashboardComponentFilter">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="RowLabelAscending"/>
+     <xsd:enumeration value="RowLabelDescending"/>
+     <xsd:enumeration value="RowValueAscending"/>
+     <xsd:enumeration value="RowValueDescending"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ChartUnits">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Auto"/>
+     <xsd:enumeration value="Integer"/>
+     <xsd:enumeration value="Hundreds"/>
+     <xsd:enumeration value="Thousands"/>
+     <xsd:enumeration value="Millions"/>
+     <xsd:enumeration value="Billions"/>
+     <xsd:enumeration value="Trillions"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ChartLegendPosition">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Right"/>
+     <xsd:enumeration value="Bottom"/>
+     <xsd:enumeration value="OnChart"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="DataCategoryGroup">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="dataCategory" type="tns:DataCategory"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="objectUsage" minOccurs="0" type="tns:ObjectUsage"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="DataCategory">
+    <xsd:sequence>
+     <xsd:element name="dataCategory" minOccurs="0" maxOccurs="unbounded" type="tns:DataCategory"/>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ObjectUsage">
+    <xsd:sequence>
+     <xsd:element name="object" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EntitlementProcess">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="businessHours" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="entryStartDateField" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="exitCriteriaBooleanFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="exitCriteriaFilterItems" minOccurs="0" maxOccurs="unbounded" type="tns:FilterItem"/>
+       <xsd:element name="exitCriteriaFormula" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="isVersionDefault" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="milestones" minOccurs="0" maxOccurs="unbounded" type="tns:EntitlementProcessMilestoneItem"/>
+       <xsd:element name="name" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="versionMaster" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="versionNotes" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="versionNumber" minOccurs="0" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="EntitlementProcessMilestoneItem">
+    <xsd:sequence>
+     <xsd:element name="businessHours" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="criteriaBooleanFilter" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="milestoneCriteriaFilterItems" minOccurs="0" maxOccurs="unbounded" type="tns:FilterItem"/>
+     <xsd:element name="milestoneCriteriaFormula" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="milestoneName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="minutesCustomClass" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="minutesToComplete" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="successActions" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowActionReference"/>
+     <xsd:element name="timeTriggers" minOccurs="0" maxOccurs="unbounded" type="tns:EntitlementProcessMilestoneTimeTrigger"/>
+     <xsd:element name="useCriteriaStartTime" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EntitlementProcessMilestoneTimeTrigger">
+    <xsd:sequence>
+     <xsd:element name="actions" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowActionReference"/>
+     <xsd:element name="timeLength" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="workflowTimeTriggerUnit" type="tns:MilestoneTimeUnits"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="MilestoneTimeUnits">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Minutes"/>
+     <xsd:enumeration value="Hours"/>
+     <xsd:enumeration value="Days"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="EntitlementSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="assetLookupLimitedToActiveEntitlementsOnAccount" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="assetLookupLimitedToActiveEntitlementsOnContact" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="assetLookupLimitedToSameAccount" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="assetLookupLimitedToSameContact" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableEntitlementVersioning" type="xsd:boolean"/>
+       <xsd:element name="enableEntitlements" type="xsd:boolean"/>
+       <xsd:element name="entitlementLookupLimitedToActiveStatus" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="entitlementLookupLimitedToSameAccount" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="entitlementLookupLimitedToSameAsset" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="entitlementLookupLimitedToSameContact" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="EntitlementTemplate">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="businessHours" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="casesPerEntitlement" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="entitlementProcess" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="isPerIncident" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="term" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="type" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="EscalationRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="ruleEntry" minOccurs="0" maxOccurs="unbounded" type="tns:RuleEntry"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="EscalationRules">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="escalationRule" minOccurs="0" maxOccurs="unbounded" type="tns:EscalationRule"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExternalDataSource">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="apiKey" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="authProvider" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="certificate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="customConfiguration" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="endpoint" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="oauthRefreshToken" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="oauthScope" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="oauthToken" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="password" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="principalType" type="tns:ExternalPrincipalType"/>
+       <xsd:element name="protocol" type="tns:AuthenticationProtocol"/>
+       <xsd:element name="repository" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="type" type="tns:ExternalDataSourceType"/>
+       <xsd:element name="username" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="version" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="ExternalPrincipalType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Anonymous"/>
+     <xsd:enumeration value="PerUser"/>
+     <xsd:enumeration value="NamedUser"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="AuthenticationProtocol">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="NoAuthentication"/>
+     <xsd:enumeration value="Oauth"/>
+     <xsd:enumeration value="Password"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ExternalDataSourceType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Datacloud"/>
+     <xsd:enumeration value="Identity"/>
+     <xsd:enumeration value="OData"/>
+     <xsd:enumeration value="SimpleURL"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FlexiPage">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="flexiPageRegions" minOccurs="0" maxOccurs="unbounded" type="tns:FlexiPageRegion"/>
+       <xsd:element name="masterLabel" type="xsd:string"/>
+       <xsd:element name="pageTemplate" type="xsd:string"/>
+       <xsd:element name="platformActionlist" minOccurs="0" type="tns:PlatformActionList"/>
+       <xsd:element name="quickActionList" minOccurs="0" type="tns:QuickActionList"/>
+       <xsd:element name="sobjectType" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="type" type="tns:FlexiPageType"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlexiPageRegion">
+    <xsd:sequence>
+     <xsd:element name="componentInstances" minOccurs="0" maxOccurs="unbounded" type="tns:ComponentInstance"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ComponentInstance">
+    <xsd:sequence>
+     <xsd:element name="componentInstanceProperties" minOccurs="0" maxOccurs="unbounded" type="tns:ComponentInstanceProperty"/>
+     <xsd:element name="componentName" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ComponentInstanceProperty">
+    <xsd:sequence>
+     <xsd:element name="name" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="value" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PlatformActionList">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="actionListContext" type="tns:PlatformActionListContext"/>
+       <xsd:element name="platformActionListItems" minOccurs="0" maxOccurs="unbounded" type="tns:PlatformActionListItem"/>
+       <xsd:element name="relatedSourceEntity" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="PlatformActionListContext">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="ListView"/>
+     <xsd:enumeration value="RelatedList"/>
+     <xsd:enumeration value="ListViewRecord"/>
+     <xsd:enumeration value="RelatedListRecord"/>
+     <xsd:enumeration value="Record"/>
+     <xsd:enumeration value="FeedElement"/>
+     <xsd:enumeration value="Chatter"/>
+     <xsd:enumeration value="Global"/>
+     <xsd:enumeration value="Flexipage"/>
+     <xsd:enumeration value="MruList"/>
+     <xsd:enumeration value="MruRow"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="PlatformActionListItem">
+    <xsd:sequence>
+     <xsd:element name="actionName" type="xsd:string"/>
+     <xsd:element name="actionType" type="tns:PlatformActionType"/>
+     <xsd:element name="sortOrder" type="xsd:int"/>
+     <xsd:element name="subtype" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="PlatformActionType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="QuickAction"/>
+     <xsd:enumeration value="StandardButton"/>
+     <xsd:enumeration value="CustomButton"/>
+     <xsd:enumeration value="ProductivityAction"/>
+     <xsd:enumeration value="ActionLink"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="QuickActionList">
+    <xsd:sequence>
+     <xsd:element name="quickActionListItems" minOccurs="0" maxOccurs="unbounded" type="tns:QuickActionListItem"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuickActionListItem">
+    <xsd:sequence>
+     <xsd:element name="quickActionName" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="FlexiPageType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AppPage"/>
+     <xsd:enumeration value="ObjectPage"/>
+     <xsd:enumeration value="RecordPage"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="Flow">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="actionCalls" minOccurs="0" maxOccurs="unbounded" type="tns:FlowActionCall"/>
+       <xsd:element name="apexPluginCalls" minOccurs="0" maxOccurs="unbounded" type="tns:FlowApexPluginCall"/>
+       <xsd:element name="assignments" minOccurs="0" maxOccurs="unbounded" type="tns:FlowAssignment"/>
+       <xsd:element name="choices" minOccurs="0" maxOccurs="unbounded" type="tns:FlowChoice"/>
+       <xsd:element name="constants" minOccurs="0" maxOccurs="unbounded" type="tns:FlowConstant"/>
+       <xsd:element name="decisions" minOccurs="0" maxOccurs="unbounded" type="tns:FlowDecision"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="dynamicChoiceSets" minOccurs="0" maxOccurs="unbounded" type="tns:FlowDynamicChoiceSet"/>
+       <xsd:element name="formulas" minOccurs="0" maxOccurs="unbounded" type="tns:FlowFormula"/>
+       <xsd:element name="interviewLabel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="loops" minOccurs="0" maxOccurs="unbounded" type="tns:FlowLoop"/>
+       <xsd:element name="processMetadataValues" minOccurs="0" maxOccurs="unbounded" type="tns:FlowMetadataValue"/>
+       <xsd:element name="processType" minOccurs="0" type="tns:FlowProcessType"/>
+       <xsd:element name="recordCreates" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRecordCreate"/>
+       <xsd:element name="recordDeletes" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRecordDelete"/>
+       <xsd:element name="recordLookups" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRecordLookup"/>
+       <xsd:element name="recordUpdates" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRecordUpdate"/>
+       <xsd:element name="screens" minOccurs="0" maxOccurs="unbounded" type="tns:FlowScreen"/>
+       <xsd:element name="startElementReference" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="steps" minOccurs="0" maxOccurs="unbounded" type="tns:FlowStep"/>
+       <xsd:element name="subflows" minOccurs="0" maxOccurs="unbounded" type="tns:FlowSubflow"/>
+       <xsd:element name="textTemplates" minOccurs="0" maxOccurs="unbounded" type="tns:FlowTextTemplate"/>
+       <xsd:element name="variables" minOccurs="0" maxOccurs="unbounded" type="tns:FlowVariable"/>
+       <xsd:element name="waits" minOccurs="0" maxOccurs="unbounded" type="tns:FlowWait"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowActionCall">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="actionName" type="xsd:string"/>
+       <xsd:element name="actionType" type="tns:InvocableActionType"/>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="faultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="inputParameters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowActionCallInputParameter"/>
+       <xsd:element name="outputParameters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowActionCallOutputParameter"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowNode">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="locationX" type="xsd:int"/>
+       <xsd:element name="locationY" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowElement">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowBaseElement">
+    <xsd:sequence>
+     <xsd:element name="processMetadataValues" minOccurs="0" maxOccurs="unbounded" type="tns:FlowMetadataValue"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FlowMetadataValue">
+    <xsd:sequence>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FlowElementReferenceOrValue">
+    <xsd:sequence>
+     <xsd:element name="booleanValue" minOccurs="0" type="xsd:boolean" nillable="true"/>
+     <xsd:element name="dateTimeValue" minOccurs="0" type="xsd:dateTime"/>
+     <xsd:element name="dateValue" minOccurs="0" type="xsd:date"/>
+     <xsd:element name="elementReference" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="numberValue" minOccurs="0" type="xsd:double" nillable="true"/>
+     <xsd:element name="stringValue" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FlowActionCallInputParameter">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowActionCallOutputParameter">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="assignToReference" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowApexPluginCallInputParameter">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowApexPluginCallOutputParameter">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="assignToReference" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowAssignmentItem">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="assignToReference" type="xsd:string"/>
+       <xsd:element name="operator" type="tns:FlowAssignmentOperator"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="FlowAssignmentOperator">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Assign"/>
+     <xsd:enumeration value="Add"/>
+     <xsd:enumeration value="Subtract"/>
+     <xsd:enumeration value="AddItem"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FlowChoiceUserInput">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="isRequired" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="promptText" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="validationRule" minOccurs="0" type="tns:FlowInputValidationRule"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowInputValidationRule">
+    <xsd:sequence>
+     <xsd:element name="errorMessage" type="xsd:string"/>
+     <xsd:element name="formulaExpression" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FlowCondition">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="leftValueReference" type="xsd:string"/>
+       <xsd:element name="operator" type="tns:FlowComparisonOperator"/>
+       <xsd:element name="rightValue" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="FlowComparisonOperator">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="EqualTo"/>
+     <xsd:enumeration value="NotEqualTo"/>
+     <xsd:enumeration value="GreaterThan"/>
+     <xsd:enumeration value="LessThan"/>
+     <xsd:enumeration value="GreaterThanOrEqualTo"/>
+     <xsd:enumeration value="LessThanOrEqualTo"/>
+     <xsd:enumeration value="StartsWith"/>
+     <xsd:enumeration value="EndsWith"/>
+     <xsd:enumeration value="Contains"/>
+     <xsd:enumeration value="IsNull"/>
+     <xsd:enumeration value="WasSet"/>
+     <xsd:enumeration value="WasSelected"/>
+     <xsd:enumeration value="WasVisited"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FlowConnector">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="targetReference" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowInputFieldAssignment">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="field" type="xsd:string"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowOutputFieldAssignment">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="assignToReference" type="xsd:string"/>
+       <xsd:element name="field" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowRecordFilter">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="field" type="xsd:string"/>
+       <xsd:element name="operator" type="tns:FlowRecordFilterOperator"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="FlowRecordFilterOperator">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="EqualTo"/>
+     <xsd:enumeration value="NotEqualTo"/>
+     <xsd:enumeration value="GreaterThan"/>
+     <xsd:enumeration value="LessThan"/>
+     <xsd:enumeration value="GreaterThanOrEqualTo"/>
+     <xsd:enumeration value="LessThanOrEqualTo"/>
+     <xsd:enumeration value="StartsWith"/>
+     <xsd:enumeration value="EndsWith"/>
+     <xsd:enumeration value="Contains"/>
+     <xsd:enumeration value="IsNull"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FlowSubflowInputAssignment">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowSubflowOutputAssignment">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="assignToReference" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowWaitEventInputParameter">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowWaitEventOutputParameter">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowBaseElement">
+      <xsd:sequence>
+       <xsd:element name="assignToReference" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowChoice">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="choiceText" type="xsd:string"/>
+       <xsd:element name="dataType" type="tns:FlowDataType"/>
+       <xsd:element name="userInput" minOccurs="0" type="tns:FlowChoiceUserInput"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="FlowDataType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Currency"/>
+     <xsd:enumeration value="Date"/>
+     <xsd:enumeration value="Number"/>
+     <xsd:enumeration value="String"/>
+     <xsd:enumeration value="Boolean"/>
+     <xsd:enumeration value="SObject"/>
+     <xsd:enumeration value="DateTime"/>
+     <xsd:enumeration value="Picklist"/>
+     <xsd:enumeration value="Multipicklist"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FlowConstant">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="dataType" type="tns:FlowDataType"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowDynamicChoiceSet">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="dataType" type="tns:FlowDataType"/>
+       <xsd:element name="displayField" type="xsd:string"/>
+       <xsd:element name="filters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRecordFilter"/>
+       <xsd:element name="limit" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="object" type="xsd:string"/>
+       <xsd:element name="outputAssignments" minOccurs="0" maxOccurs="unbounded" type="tns:FlowOutputFieldAssignment"/>
+       <xsd:element name="sortField" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="sortOrder" minOccurs="0" type="tns:SortOrder"/>
+       <xsd:element name="valueField" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowFormula">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="dataType" minOccurs="0" type="tns:FlowDataType"/>
+       <xsd:element name="expression" type="xsd:string"/>
+       <xsd:element name="scale" minOccurs="0" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="conditionLogic" type="xsd:string"/>
+       <xsd:element name="conditions" minOccurs="0" maxOccurs="unbounded" type="tns:FlowCondition"/>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="label" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowScreenField">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="choiceReferences" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="dataType" minOccurs="0" type="tns:FlowDataType"/>
+       <xsd:element name="defaultSelectedChoiceReference" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultValue" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+       <xsd:element name="fieldText" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="fieldType" type="tns:FlowScreenFieldType"/>
+       <xsd:element name="helpText" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="isRequired" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="scale" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="validationRule" minOccurs="0" type="tns:FlowInputValidationRule"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="FlowScreenFieldType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="DisplayText"/>
+     <xsd:enumeration value="InputField"/>
+     <xsd:enumeration value="LargeTextArea"/>
+     <xsd:enumeration value="PasswordField"/>
+     <xsd:enumeration value="RadioButtons"/>
+     <xsd:enumeration value="DropdownBox"/>
+     <xsd:enumeration value="MultiSelectCheckboxes"/>
+     <xsd:enumeration value="MultiSelectPicklist"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FlowTextTemplate">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="text" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowVariable">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="dataType" type="tns:FlowDataType"/>
+       <xsd:element name="isCollection" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="isInput" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="isOutput" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="objectType" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="scale" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="value" minOccurs="0" type="tns:FlowElementReferenceOrValue"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowWaitEvent">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowElement">
+      <xsd:sequence>
+       <xsd:element name="conditionLogic" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="conditions" minOccurs="0" maxOccurs="unbounded" type="tns:FlowCondition"/>
+       <xsd:element name="connector" type="tns:FlowConnector"/>
+       <xsd:element name="eventType" type="xsd:string"/>
+       <xsd:element name="inputParameters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowWaitEventInputParameter"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="outputParameters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowWaitEventOutputParameter"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowApexPluginCall">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="apexClass" type="xsd:string"/>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="faultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="inputParameters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowApexPluginCallInputParameter"/>
+       <xsd:element name="outputParameters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowApexPluginCallOutputParameter"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowAssignment">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="assignmentItems" minOccurs="0" maxOccurs="unbounded" type="tns:FlowAssignmentItem"/>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowDecision">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="defaultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="defaultConnectorLabel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="rules" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRule"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowLoop">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="assignNextValueToReference" type="xsd:string"/>
+       <xsd:element name="collectionReference" type="xsd:string"/>
+       <xsd:element name="iterationOrder" minOccurs="0" type="tns:IterationOrder"/>
+       <xsd:element name="nextValueConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="noMoreValuesConnector" minOccurs="0" type="tns:FlowConnector"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="IterationOrder">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Asc"/>
+     <xsd:enumeration value="Desc"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FlowRecordCreate">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="assignRecordIdToReference" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="faultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="inputAssignments" minOccurs="0" maxOccurs="unbounded" type="tns:FlowInputFieldAssignment"/>
+       <xsd:element name="inputReference" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="object" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowRecordDelete">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="faultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="filters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRecordFilter"/>
+       <xsd:element name="inputReference" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="object" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowRecordLookup">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="assignNullValuesIfNoRecordsFound" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="faultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="filters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRecordFilter"/>
+       <xsd:element name="object" type="xsd:string"/>
+       <xsd:element name="outputAssignments" minOccurs="0" maxOccurs="unbounded" type="tns:FlowOutputFieldAssignment"/>
+       <xsd:element name="outputReference" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="queriedFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="sortField" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="sortOrder" minOccurs="0" type="tns:SortOrder"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowRecordUpdate">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="faultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="filters" minOccurs="0" maxOccurs="unbounded" type="tns:FlowRecordFilter"/>
+       <xsd:element name="inputAssignments" minOccurs="0" maxOccurs="unbounded" type="tns:FlowInputFieldAssignment"/>
+       <xsd:element name="inputReference" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="object" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowScreen">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="allowBack" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="allowFinish" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="allowPause" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="tns:FlowScreenField"/>
+       <xsd:element name="helpText" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="pausedText" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowStep">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="connectors" minOccurs="0" maxOccurs="unbounded" type="tns:FlowConnector"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowSubflow">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="connector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="flowName" type="xsd:string"/>
+       <xsd:element name="inputAssignments" minOccurs="0" maxOccurs="unbounded" type="tns:FlowSubflowInputAssignment"/>
+       <xsd:element name="outputAssignments" minOccurs="0" maxOccurs="unbounded" type="tns:FlowSubflowOutputAssignment"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FlowWait">
+    <xsd:complexContent>
+     <xsd:extension base="tns:FlowNode">
+      <xsd:sequence>
+       <xsd:element name="defaultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="defaultConnectorLabel" type="xsd:string"/>
+       <xsd:element name="faultConnector" minOccurs="0" type="tns:FlowConnector"/>
+       <xsd:element name="waitEvents" minOccurs="0" maxOccurs="unbounded" type="tns:FlowWaitEvent"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="InvocableActionType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="apex"/>
+     <xsd:enumeration value="chatterPost"/>
+     <xsd:enumeration value="contentWorkspaceEnableFolders"/>
+     <xsd:enumeration value="emailAlert"/>
+     <xsd:enumeration value="emailSimple"/>
+     <xsd:enumeration value="flow"/>
+     <xsd:enumeration value="metricRefresh"/>
+     <xsd:enumeration value="quickAction"/>
+     <xsd:enumeration value="submit"/>
+     <xsd:enumeration value="thanks"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="FlowProcessType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AutoLaunchedFlow"/>
+     <xsd:enumeration value="Flow"/>
+     <xsd:enumeration value="Workflow"/>
+     <xsd:enumeration value="LoginFlow"/>
+     <xsd:enumeration value="ActionPlan"/>
+     <xsd:enumeration value="JourneyBuilderIntegration"/>
+     <xsd:enumeration value="UserProvisioningFlow"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FlowDefinition">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="activeVersionNumber" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="masterLabel" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Folder">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="accessType" minOccurs="0" type="tns:FolderAccessTypes"/>
+       <xsd:element name="folderShares" minOccurs="0" maxOccurs="unbounded" type="tns:FolderShare"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="publicFolderAccess" minOccurs="0" type="tns:PublicFolderAccess"/>
+       <xsd:element name="sharedTo" minOccurs="0" type="tns:SharedTo"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="FolderAccessTypes">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Shared"/>
+     <xsd:enumeration value="Public"/>
+     <xsd:enumeration value="Hidden"/>
+     <xsd:enumeration value="PublicInternal"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FolderShare">
+    <xsd:sequence>
+     <xsd:element name="accessLevel" type="tns:FolderShareAccessLevel"/>
+     <xsd:element name="sharedTo" type="xsd:string"/>
+     <xsd:element name="sharedToType" type="tns:FolderSharedToType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="FolderShareAccessLevel">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="View"/>
+     <xsd:enumeration value="EditAllContents"/>
+     <xsd:enumeration value="Manage"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="FolderSharedToType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Group"/>
+     <xsd:enumeration value="Role"/>
+     <xsd:enumeration value="RoleAndSubordinates"/>
+     <xsd:enumeration value="RoleAndSubordinatesInternal"/>
+     <xsd:enumeration value="Manager"/>
+     <xsd:enumeration value="ManagerAndSubordinatesInternal"/>
+     <xsd:enumeration value="Organization"/>
+     <xsd:enumeration value="Territory"/>
+     <xsd:enumeration value="TerritoryAndSubordinates"/>
+     <xsd:enumeration value="AllPrmUsers"/>
+     <xsd:enumeration value="User"/>
+     <xsd:enumeration value="PartnerUser"/>
+     <xsd:enumeration value="AllCspUsers"/>
+     <xsd:enumeration value="CustomerPortalUser"/>
+     <xsd:enumeration value="PortalRole"/>
+     <xsd:enumeration value="PortalRoleAndSubordinates"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="PublicFolderAccess">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="ReadOnly"/>
+     <xsd:enumeration value="ReadWrite"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="DashboardFolder">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Folder">
+      <xsd:sequence/>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentFolder">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Folder">
+      <xsd:sequence/>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmailFolder">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Folder">
+      <xsd:sequence/>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReportFolder">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Folder">
+      <xsd:sequence/>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastingSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="displayCurrency" minOccurs="0" type="tns:DisplayCurrency"/>
+       <xsd:element name="enableForecasts" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="forecastingCategoryMappings" minOccurs="0" maxOccurs="unbounded" type="tns:ForecastingCategoryMapping"/>
+       <xsd:element name="forecastingTypeSettings" minOccurs="0" maxOccurs="unbounded" type="tns:ForecastingTypeSettings"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="DisplayCurrency">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="CORPORATE"/>
+     <xsd:enumeration value="PERSONAL"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ForecastingCategoryMapping">
+    <xsd:sequence>
+     <xsd:element name="forecastingItemCategoryApiName" type="xsd:string"/>
+     <xsd:element name="weightedSourceCategories" minOccurs="0" maxOccurs="unbounded" type="tns:WeightedSourceCategory"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WeightedSourceCategory">
+    <xsd:sequence>
+     <xsd:element name="sourceCategoryApiName" type="xsd:string"/>
+     <xsd:element name="weight" type="xsd:double"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastingTypeSettings">
+    <xsd:sequence>
+     <xsd:element name="active" type="xsd:boolean"/>
+     <xsd:element name="adjustmentsSettings" type="tns:AdjustmentsSettings"/>
+     <xsd:element name="displayedCategoryApiNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="forecastRangeSettings" type="tns:ForecastRangeSettings"/>
+     <xsd:element name="forecastedCategoryApiNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="managerAdjustableCategoryApiNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="opportunityListFieldsSelectedSettings" type="tns:OpportunityListFieldsSelectedSettings"/>
+     <xsd:element name="ownerAdjustableCategoryApiNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="quotasSettings" type="tns:QuotasSettings"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AdjustmentsSettings">
+    <xsd:sequence>
+     <xsd:element name="enableAdjustments" type="xsd:boolean"/>
+     <xsd:element name="enableOwnerAdjustments" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastRangeSettings">
+    <xsd:sequence>
+     <xsd:element name="beginning" type="xsd:int"/>
+     <xsd:element name="displaying" type="xsd:int"/>
+     <xsd:element name="periodType" type="tns:PeriodTypes"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="PeriodTypes">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Month"/>
+     <xsd:enumeration value="Quarter"/>
+     <xsd:enumeration value="Week"/>
+     <xsd:enumeration value="Year"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="OpportunityListFieldsSelectedSettings">
+    <xsd:sequence>
+     <xsd:element name="field" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuotasSettings">
+    <xsd:sequence>
+     <xsd:element name="showQuotas" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Group">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="doesIncludeBosses" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="name" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="HomePageComponent">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="body" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="links" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="pageComponentType" type="tns:PageComponentType"/>
+       <xsd:element name="showLabel" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showScrollbars" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="width" minOccurs="0" type="tns:PageComponentWidth"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="PageComponentType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="links"/>
+     <xsd:enumeration value="htmlArea"/>
+     <xsd:enumeration value="imageOrNote"/>
+     <xsd:enumeration value="visualforcePage"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="PageComponentWidth">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="narrow"/>
+     <xsd:enumeration value="wide"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="HomePageLayout">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="narrowComponents" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="wideComponents" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="IdeasSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableChatterProfile" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableIdeaThemes" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableIdeas" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableIdeasReputation" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="halfLife" minOccurs="0" type="xsd:double"/>
+       <xsd:element name="ideasProfilePage" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstalledPackage">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="password" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="versionNumber" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="KnowledgeSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="answers" minOccurs="0" type="tns:KnowledgeAnswerSettings"/>
+       <xsd:element name="cases" minOccurs="0" type="tns:KnowledgeCaseSettings"/>
+       <xsd:element name="defaultLanguage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="enableChatterQuestionKBDeflection" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableCreateEditOnArticlesTab" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableExternalMediaContent" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableKnowledge" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="languages" minOccurs="0" type="tns:KnowledgeLanguageSettings"/>
+       <xsd:element name="showArticleSummariesCustomerPortal" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showArticleSummariesInternalApp" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showArticleSummariesPartnerPortal" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showValidationStatusField" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="KnowledgeAnswerSettings">
+    <xsd:sequence>
+     <xsd:element name="assignTo" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="defaultArticleType" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="enableArticleCreation" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="KnowledgeCaseSettings">
+    <xsd:sequence>
+     <xsd:element name="articlePDFCreationProfile" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="articlePublicSharingSites" minOccurs="0" type="tns:KnowledgeSitesSettings"/>
+     <xsd:element name="articlePublicSharingSitesChatterAnswers" minOccurs="0" type="tns:KnowledgeSitesSettings"/>
+     <xsd:element name="assignTo" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="customizationClass" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="defaultContributionArticleType" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="editor" minOccurs="0" type="tns:KnowledgeCaseEditor"/>
+     <xsd:element name="enableArticleCreation" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableArticlePublicSharingSites" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="useProfileForPDFCreation" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="KnowledgeSitesSettings">
+    <xsd:sequence>
+     <xsd:element name="site" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="KnowledgeCaseEditor">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="simple"/>
+     <xsd:enumeration value="standard"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="KnowledgeLanguageSettings">
+    <xsd:sequence>
+     <xsd:element name="language" minOccurs="0" maxOccurs="unbounded" type="tns:KnowledgeLanguage"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="KnowledgeLanguage">
+    <xsd:sequence>
+     <xsd:element name="active" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="defaultAssignee" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="defaultAssigneeType" minOccurs="0" type="tns:KnowledgeLanguageLookupValueType"/>
+     <xsd:element name="defaultReviewer" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="defaultReviewerType" minOccurs="0" type="tns:KnowledgeLanguageLookupValueType"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="KnowledgeLanguageLookupValueType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="User"/>
+     <xsd:enumeration value="Queue"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="Layout">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="customButtons" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="customConsoleComponents" minOccurs="0" type="tns:CustomConsoleComponents"/>
+       <xsd:element name="emailDefault" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="excludeButtons" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="feedLayout" minOccurs="0" type="tns:FeedLayout"/>
+       <xsd:element name="headers" minOccurs="0" maxOccurs="unbounded" type="tns:LayoutHeader"/>
+       <xsd:element name="layoutSections" minOccurs="0" maxOccurs="unbounded" type="tns:LayoutSection"/>
+       <xsd:element name="miniLayout" minOccurs="0" type="tns:MiniLayout"/>
+       <xsd:element name="multilineLayoutFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="platformActionList" minOccurs="0" type="tns:PlatformActionList"/>
+       <xsd:element name="quickActionList" minOccurs="0" type="tns:QuickActionList"/>
+       <xsd:element name="relatedContent" minOccurs="0" type="tns:RelatedContent"/>
+       <xsd:element name="relatedLists" minOccurs="0" maxOccurs="unbounded" type="tns:RelatedListItem"/>
+       <xsd:element name="relatedObjects" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="runAssignmentRulesDefault" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showEmailCheckbox" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showHighlightsPanel" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showInteractionLogPanel" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showKnowledgeComponent" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showRunAssignmentRulesCheckbox" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showSolutionSection" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showSubmitAndAttachButton" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="summaryLayout" minOccurs="0" type="tns:SummaryLayout"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomConsoleComponents">
+    <xsd:sequence>
+     <xsd:element name="primaryTabComponents" minOccurs="0" type="tns:PrimaryTabComponents"/>
+     <xsd:element name="subtabComponents" minOccurs="0" type="tns:SubtabComponents"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PrimaryTabComponents">
+    <xsd:sequence>
+     <xsd:element name="containers" minOccurs="0" maxOccurs="unbounded" type="tns:Container"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Container">
+    <xsd:sequence>
+     <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="isContainerAutoSizeEnabled" type="xsd:boolean"/>
+     <xsd:element name="region" type="xsd:string"/>
+     <xsd:element name="sidebarComponents" minOccurs="0" maxOccurs="unbounded" type="tns:SidebarComponent"/>
+     <xsd:element name="style" type="xsd:string"/>
+     <xsd:element name="unit" type="xsd:string"/>
+     <xsd:element name="width" minOccurs="0" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SidebarComponent">
+    <xsd:sequence>
+     <xsd:element name="componentType" type="xsd:string"/>
+     <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="lookup" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="relatedLists" minOccurs="0" maxOccurs="unbounded" type="tns:RelatedList"/>
+     <xsd:element name="unit" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="width" minOccurs="0" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RelatedList">
+    <xsd:sequence>
+     <xsd:element name="hideOnDetail" type="xsd:boolean"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SubtabComponents">
+    <xsd:sequence>
+     <xsd:element name="containers" minOccurs="0" maxOccurs="unbounded" type="tns:Container"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeedLayout">
+    <xsd:sequence>
+     <xsd:element name="autocollapsePublisher" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="compactFeed" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="feedFilterPosition" minOccurs="0" type="tns:FeedLayoutFilterPosition"/>
+     <xsd:element name="feedFilters" minOccurs="0" maxOccurs="unbounded" type="tns:FeedLayoutFilter"/>
+     <xsd:element name="fullWidthFeed" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="hideSidebar" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="highlightExternalFeedItems" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="leftComponents" minOccurs="0" maxOccurs="unbounded" type="tns:FeedLayoutComponent"/>
+     <xsd:element name="rightComponents" minOccurs="0" maxOccurs="unbounded" type="tns:FeedLayoutComponent"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="FeedLayoutFilterPosition">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="CenterDropDown"/>
+     <xsd:enumeration value="LeftFixed"/>
+     <xsd:enumeration value="LeftFloat"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FeedLayoutFilter">
+    <xsd:sequence>
+     <xsd:element name="feedFilterType" type="tns:FeedLayoutFilterType"/>
+     <xsd:element name="feedItemType" minOccurs="0" type="tns:FeedItemType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="FeedLayoutFilterType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AllUpdates"/>
+     <xsd:enumeration value="FeedItemType"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="FeedLayoutComponent">
+    <xsd:sequence>
+     <xsd:element name="componentType" type="tns:FeedLayoutComponentType"/>
+     <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="FeedLayoutComponentType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="HelpAndToolLinks"/>
+     <xsd:enumeration value="CustomButtons"/>
+     <xsd:enumeration value="Following"/>
+     <xsd:enumeration value="Followers"/>
+     <xsd:enumeration value="CustomLinks"/>
+     <xsd:enumeration value="Milestones"/>
+     <xsd:enumeration value="Topics"/>
+     <xsd:enumeration value="Visualforce"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="LayoutHeader">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="PersonalTagging"/>
+     <xsd:enumeration value="PublicTagging"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="LayoutSection">
+    <xsd:sequence>
+     <xsd:element name="customLabel" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="detailHeading" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="editHeading" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="layoutColumns" minOccurs="0" maxOccurs="unbounded" type="tns:LayoutColumn"/>
+     <xsd:element name="style" type="tns:LayoutSectionStyle"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LayoutColumn">
+    <xsd:sequence>
+     <xsd:element name="layoutItems" minOccurs="0" maxOccurs="unbounded" type="tns:LayoutItem"/>
+     <xsd:element name="reserved" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LayoutItem">
+    <xsd:sequence>
+     <xsd:element name="analyticsCloudComponent" minOccurs="0" type="tns:AnalyticsCloudComponentLayoutItem"/>
+     <xsd:element name="behavior" minOccurs="0" type="tns:UiBehavior"/>
+     <xsd:element name="canvas" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="component" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="customLink" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="emptySpace" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="field" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="reportChartComponent" minOccurs="0" type="tns:ReportChartComponentLayoutItem"/>
+     <xsd:element name="scontrol" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="showLabel" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showScrollbars" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="width" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AnalyticsCloudComponentLayoutItem">
+    <xsd:sequence>
+     <xsd:element name="assetType" type="xsd:string"/>
+     <xsd:element name="devName" type="xsd:string"/>
+     <xsd:element name="error" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="filter" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="hideOnError" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showTitle" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="width" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="UiBehavior">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Edit"/>
+     <xsd:enumeration value="Required"/>
+     <xsd:enumeration value="Readonly"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportChartComponentLayoutItem">
+    <xsd:sequence>
+     <xsd:element name="cacheData" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="contextFilterableField" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="error" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="hideOnError" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="includeContext" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="reportName" type="xsd:string"/>
+     <xsd:element name="showTitle" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="size" minOccurs="0" type="tns:ReportChartComponentSize"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ReportChartComponentSize">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="SMALL"/>
+     <xsd:enumeration value="MEDIUM"/>
+     <xsd:enumeration value="LARGE"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="LayoutSectionStyle">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="TwoColumnsTopToBottom"/>
+     <xsd:enumeration value="TwoColumnsLeftToRight"/>
+     <xsd:enumeration value="OneColumn"/>
+     <xsd:enumeration value="CustomLinks"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="MiniLayout">
+    <xsd:sequence>
+     <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="relatedLists" minOccurs="0" maxOccurs="unbounded" type="tns:RelatedListItem"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RelatedListItem">
+    <xsd:sequence>
+     <xsd:element name="customButtons" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="excludeButtons" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="relatedList" type="xsd:string"/>
+     <xsd:element name="sortField" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="sortOrder" minOccurs="0" type="tns:SortOrder"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RelatedContent">
+    <xsd:sequence>
+     <xsd:element name="relatedContentItems" minOccurs="0" maxOccurs="unbounded" type="tns:RelatedContentItem"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RelatedContentItem">
+    <xsd:sequence>
+     <xsd:element name="layoutItem" type="tns:LayoutItem"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SummaryLayout">
+    <xsd:sequence>
+     <xsd:element name="masterLabel" type="xsd:string"/>
+     <xsd:element name="sizeX" type="xsd:int"/>
+     <xsd:element name="sizeY" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="sizeZ" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="summaryLayoutItems" minOccurs="0" maxOccurs="unbounded" type="tns:SummaryLayoutItem"/>
+     <xsd:element name="summaryLayoutStyle" type="tns:SummaryLayoutStyle"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SummaryLayoutItem">
+    <xsd:sequence>
+     <xsd:element name="customLink" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="field" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="posX" type="xsd:int"/>
+     <xsd:element name="posY" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="posZ" minOccurs="0" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="SummaryLayoutStyle">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Default"/>
+     <xsd:enumeration value="QuoteTemplate"/>
+     <xsd:enumeration value="DefaultQuoteTemplate"/>
+     <xsd:enumeration value="CaseInteraction"/>
+     <xsd:enumeration value="QuickActionLayoutLeftRight"/>
+     <xsd:enumeration value="QuickActionLayoutTopDown"/>
+     <xsd:enumeration value="ProcessAssistant"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="Letterhead">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="available" type="xsd:boolean"/>
+       <xsd:element name="backgroundColor" type="xsd:string"/>
+       <xsd:element name="bodyColor" type="xsd:string"/>
+       <xsd:element name="bottomLine" type="tns:LetterheadLine"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="footer" type="tns:LetterheadHeaderFooter"/>
+       <xsd:element name="header" type="tns:LetterheadHeaderFooter"/>
+       <xsd:element name="middleLine" type="tns:LetterheadLine"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="topLine" type="tns:LetterheadLine"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="LetterheadLine">
+    <xsd:sequence>
+     <xsd:element name="color" type="xsd:string"/>
+     <xsd:element name="height" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LetterheadHeaderFooter">
+    <xsd:sequence>
+     <xsd:element name="backgroundColor" type="xsd:string"/>
+     <xsd:element name="height" type="xsd:int"/>
+     <xsd:element name="horizontalAlignment" minOccurs="0" type="tns:LetterheadHorizontalAlignment"/>
+     <xsd:element name="logo" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="verticalAlignment" minOccurs="0" type="tns:LetterheadVerticalAlignment"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="LetterheadHorizontalAlignment">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Left"/>
+     <xsd:enumeration value="Center"/>
+     <xsd:enumeration value="Right"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="LetterheadVerticalAlignment">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Top"/>
+     <xsd:enumeration value="Middle"/>
+     <xsd:enumeration value="Bottom"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="LicenseDefinition">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="aggregationGroup" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="isPublished" type="xsd:boolean"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="licensedCustomPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:LicensedCustomPermissions"/>
+       <xsd:element name="licensingAuthority" type="xsd:string"/>
+       <xsd:element name="licensingAuthorityProvider" type="xsd:string"/>
+       <xsd:element name="minPlatformVersion" type="xsd:int"/>
+       <xsd:element name="origin" type="xsd:string"/>
+       <xsd:element name="revision" type="xsd:int"/>
+       <xsd:element name="trialLicenseDuration" type="xsd:int"/>
+       <xsd:element name="trialLicenseQuantity" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="LicensedCustomPermissions">
+    <xsd:sequence>
+     <xsd:element name="customPermission" type="xsd:string"/>
+     <xsd:element name="licenseDefinition" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LiveAgentSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableLiveAgent" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="LiveChatAgentConfig">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="assignments" minOccurs="0" type="tns:AgentConfigAssignments"/>
+       <xsd:element name="autoGreeting" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="capacity" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="criticalWaitTime" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="customAgentName" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="enableAgentFileTransfer" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableAgentSneakPeek" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableAutoAwayOnDecline" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableAutoAwayOnPushTimeout" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableChatConferencing" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableChatMonitoring" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableChatTransfer" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableLogoutSound" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableNotifications" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableRequestSound" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableSneakPeek" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableVisitorBlocking" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableWhisperMessage" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="supervisorDefaultAgentStatusFilter" minOccurs="0" type="tns:SupervisorAgentStatusFilter"/>
+       <xsd:element name="supervisorDefaultButtonFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="supervisorDefaultSkillFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="supervisorSkills" minOccurs="0" type="tns:SupervisorAgentConfigSkills"/>
+       <xsd:element name="transferableButtons" minOccurs="0" type="tns:AgentConfigButtons"/>
+       <xsd:element name="transferableSkills" minOccurs="0" type="tns:AgentConfigSkills"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgentConfigAssignments">
+    <xsd:sequence>
+     <xsd:element name="profiles" minOccurs="0" type="tns:AgentConfigProfileAssignments"/>
+     <xsd:element name="users" minOccurs="0" type="tns:AgentConfigUserAssignments"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AgentConfigProfileAssignments">
+    <xsd:sequence>
+     <xsd:element name="profile" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AgentConfigUserAssignments">
+    <xsd:sequence>
+     <xsd:element name="user" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="SupervisorAgentStatusFilter">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Online"/>
+     <xsd:enumeration value="Away"/>
+     <xsd:enumeration value="Offline"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="SupervisorAgentConfigSkills">
+    <xsd:sequence>
+     <xsd:element name="skill" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AgentConfigButtons">
+    <xsd:sequence>
+     <xsd:element name="button" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AgentConfigSkills">
+    <xsd:sequence>
+     <xsd:element name="skill" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LiveChatButton">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="animation" minOccurs="0" type="tns:LiveChatButtonPresentation"/>
+       <xsd:element name="autoGreeting" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="chatPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="customAgentName" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="deployments" minOccurs="0" type="tns:LiveChatButtonDeployments"/>
+       <xsd:element name="enableQueue" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="inviteEndPosition" minOccurs="0" type="tns:LiveChatButtonInviteEndPosition"/>
+       <xsd:element name="inviteImage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="inviteStartPosition" minOccurs="0" type="tns:LiveChatButtonInviteStartPosition"/>
+       <xsd:element name="isActive" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="numberOfReroutingAttempts" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="offlineImage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="onlineImage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="optionsCustomRoutingIsEnabled" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="optionsHasInviteAfterAccept" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="optionsHasInviteAfterReject" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="optionsHasRerouteDeclinedRequest" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="optionsIsAutoAccept" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="optionsIsInviteAutoRemove" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="overallQueueLength" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="perAgentQueueLength" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="postChatPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="postChatUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="preChatFormPage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="preChatFormUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="pushTimeOut" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="routingType" type="tns:LiveChatButtonRoutingType"/>
+       <xsd:element name="site" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="skills" minOccurs="0" type="tns:LiveChatButtonSkills"/>
+       <xsd:element name="timeToRemoveInvite" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="type" type="tns:LiveChatButtonType"/>
+       <xsd:element name="windowLanguage" minOccurs="0" type="tns:Language"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="LiveChatButtonPresentation">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Slide"/>
+     <xsd:enumeration value="Fade"/>
+     <xsd:enumeration value="Appear"/>
+     <xsd:enumeration value="Custom"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="LiveChatButtonDeployments">
+    <xsd:sequence>
+     <xsd:element name="deployment" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="LiveChatButtonInviteEndPosition">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="TopLeft"/>
+     <xsd:enumeration value="Top"/>
+     <xsd:enumeration value="TopRight"/>
+     <xsd:enumeration value="Left"/>
+     <xsd:enumeration value="Center"/>
+     <xsd:enumeration value="Right"/>
+     <xsd:enumeration value="BottomLeft"/>
+     <xsd:enumeration value="Bottom"/>
+     <xsd:enumeration value="BottomRight"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="LiveChatButtonInviteStartPosition">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="TopLeft"/>
+     <xsd:enumeration value="TopLeftTop"/>
+     <xsd:enumeration value="Top"/>
+     <xsd:enumeration value="TopRightTop"/>
+     <xsd:enumeration value="TopRight"/>
+     <xsd:enumeration value="TopRightRight"/>
+     <xsd:enumeration value="Right"/>
+     <xsd:enumeration value="BottomRightRight"/>
+     <xsd:enumeration value="BottomRight"/>
+     <xsd:enumeration value="BottomRightBottom"/>
+     <xsd:enumeration value="Bottom"/>
+     <xsd:enumeration value="BottomLeftBottom"/>
+     <xsd:enumeration value="BottomLeft"/>
+     <xsd:enumeration value="BottomLeftLeft"/>
+     <xsd:enumeration value="Left"/>
+     <xsd:enumeration value="TopLeftLeft"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="LiveChatButtonRoutingType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Choice"/>
+     <xsd:enumeration value="LeastActive"/>
+     <xsd:enumeration value="MostAvailable"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="LiveChatButtonSkills">
+    <xsd:sequence>
+     <xsd:element name="skill" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="LiveChatButtonType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Standard"/>
+     <xsd:enumeration value="Invite"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="LiveChatDeployment">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="brandingImage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="displayQueuePosition" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="domainWhiteList" minOccurs="0" type="tns:LiveChatDeploymentDomainWhitelist"/>
+       <xsd:element name="enablePrechatApi" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableTranscriptSave" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="mobileBrandingImage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="site" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="windowTitle" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="LiveChatDeploymentDomainWhitelist">
+    <xsd:sequence>
+     <xsd:element name="domain" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ManagedTopic">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="managedTopicType" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="position" type="xsd:int"/>
+       <xsd:element name="topicDescription" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManagedTopics">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="managedTopic" minOccurs="0" maxOccurs="unbounded" type="tns:ManagedTopic"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarketingActionSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableMarketingAction" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarketingResourceType">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="masterLabel" type="xsd:string"/>
+       <xsd:element name="object" type="xsd:string"/>
+       <xsd:element name="provider" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MatchingRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="matchingRuleItems" minOccurs="0" maxOccurs="unbounded" type="tns:MatchingRuleItem"/>
+       <xsd:element name="ruleStatus" type="tns:MatchingRuleStatus"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MatchingRuleItem">
+    <xsd:sequence>
+     <xsd:element name="blankValueBehavior" minOccurs="0" type="tns:BlankValueBehavior"/>
+     <xsd:element name="fieldName" type="xsd:string"/>
+     <xsd:element name="matchingMethod" type="tns:MatchingMethod"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="BlankValueBehavior">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="MatchBlanks"/>
+     <xsd:enumeration value="NullNotAllowed"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="MatchingMethod">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Exact"/>
+     <xsd:enumeration value="FirstName"/>
+     <xsd:enumeration value="LastName"/>
+     <xsd:enumeration value="CompanyName"/>
+     <xsd:enumeration value="Phone"/>
+     <xsd:enumeration value="City"/>
+     <xsd:enumeration value="Street"/>
+     <xsd:enumeration value="Zip"/>
+     <xsd:enumeration value="Title"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="MatchingRuleStatus">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Inactive"/>
+     <xsd:enumeration value="DeactivationFailed"/>
+     <xsd:enumeration value="Activating"/>
+     <xsd:enumeration value="Deactivating"/>
+     <xsd:enumeration value="Active"/>
+     <xsd:enumeration value="ActivationFailed"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="MatchingRules">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="matchingRules" minOccurs="0" maxOccurs="unbounded" type="tns:MatchingRule"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MetadataWithContent">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="content" minOccurs="0" type="xsd:base64Binary"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApexClass">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="apiVersion" type="xsd:double"/>
+       <xsd:element name="packageVersions" minOccurs="0" maxOccurs="unbounded" type="tns:PackageVersion"/>
+       <xsd:element name="status" type="tns:ApexCodeUnitStatus"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackageVersion">
+    <xsd:sequence>
+     <xsd:element name="majorNumber" type="xsd:int"/>
+     <xsd:element name="minorNumber" type="xsd:int"/>
+     <xsd:element name="namespace" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ApexCodeUnitStatus">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Inactive"/>
+     <xsd:enumeration value="Active"/>
+     <xsd:enumeration value="Deleted"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ApexComponent">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="apiVersion" minOccurs="0" type="xsd:double"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="packageVersions" minOccurs="0" maxOccurs="unbounded" type="tns:PackageVersion"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApexPage">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="apiVersion" type="xsd:double"/>
+       <xsd:element name="availableInTouch" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="confirmationTokenRequired" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="packageVersions" minOccurs="0" maxOccurs="unbounded" type="tns:PackageVersion"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApexTrigger">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="apiVersion" type="xsd:double"/>
+       <xsd:element name="packageVersions" minOccurs="0" maxOccurs="unbounded" type="tns:PackageVersion"/>
+       <xsd:element name="status" type="tns:ApexCodeUnitStatus"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="DataPipeline">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="apiVersion" type="xsd:double"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="scriptType" type="tns:DataPipelineType"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="DataPipelineType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Pig"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="Document">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="internalUseOnly" type="xsd:boolean"/>
+       <xsd:element name="keywords" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="public" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmailTemplate">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="apiVersion" minOccurs="0" type="xsd:double"/>
+       <xsd:element name="attachedDocuments" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="attachments" minOccurs="0" maxOccurs="unbounded" type="tns:Attachment"/>
+       <xsd:element name="available" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="encodingKey" type="tns:Encoding"/>
+       <xsd:element name="letterhead" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="packageVersions" minOccurs="0" maxOccurs="unbounded" type="tns:PackageVersion"/>
+       <xsd:element name="style" type="tns:EmailTemplateStyle"/>
+       <xsd:element name="subject" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="textOnly" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="type" type="tns:EmailTemplateType"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Attachment">
+    <xsd:sequence>
+     <xsd:element name="content" type="xsd:base64Binary"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="EmailTemplateStyle">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="none"/>
+     <xsd:enumeration value="freeForm"/>
+     <xsd:enumeration value="formalLetter"/>
+     <xsd:enumeration value="promotionRight"/>
+     <xsd:enumeration value="promotionLeft"/>
+     <xsd:enumeration value="newsletter"/>
+     <xsd:enumeration value="products"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="EmailTemplateType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="text"/>
+     <xsd:enumeration value="html"/>
+     <xsd:enumeration value="custom"/>
+     <xsd:enumeration value="visualforce"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="Scontrol">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="contentSource" type="tns:SControlContentSource"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="encodingKey" type="tns:Encoding"/>
+       <xsd:element name="fileContent" minOccurs="0" type="xsd:base64Binary"/>
+       <xsd:element name="fileName" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="supportsCaching" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="SControlContentSource">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="HTML"/>
+     <xsd:enumeration value="URL"/>
+     <xsd:enumeration value="Snippet"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="SiteDotCom">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="siteType" type="tns:SiteType"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="StaticResource">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="cacheControl" type="tns:StaticResourceCacheControl"/>
+       <xsd:element name="contentType" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="StaticResourceCacheControl">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Private"/>
+     <xsd:enumeration value="Public"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="UiPlugin">
+    <xsd:complexContent>
+     <xsd:extension base="tns:MetadataWithContent">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="extensionPointIdentifier" type="xsd:string"/>
+       <xsd:element name="isEnabled" type="xsd:boolean"/>
+       <xsd:element name="language" type="xsd:string"/>
+       <xsd:element name="masterLabel" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MilestoneType">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="recurrenceType" minOccurs="0" type="tns:MilestoneTypeRecurrenceType"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="MilestoneTypeRecurrenceType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="none"/>
+     <xsd:enumeration value="recursIndependently"/>
+     <xsd:enumeration value="recursChained"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="MobileSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="chatterMobile" minOccurs="0" type="tns:ChatterMobileSettings"/>
+       <xsd:element name="dashboardMobile" minOccurs="0" type="tns:DashboardMobileSettings"/>
+       <xsd:element name="salesforceMobile" minOccurs="0" type="tns:SFDCMobileSettings"/>
+       <xsd:element name="touchMobile" minOccurs="0" type="tns:TouchMobileSettings"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChatterMobileSettings">
+    <xsd:sequence>
+     <xsd:element name="enablePushNotifications" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DashboardMobileSettings">
+    <xsd:sequence>
+     <xsd:element name="enableDashboardIPadApp" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SFDCMobileSettings">
+    <xsd:sequence>
+     <xsd:element name="enableMobileLite" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableUserToDeviceLinking" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TouchMobileSettings">
+    <xsd:sequence>
+     <xsd:element name="enableTouchAppIPad" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableTouchAppIPhone" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableTouchBrowserIPad" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableTouchIosPhone" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableVisualforceInTouch" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="NameSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableMiddleName" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableNameSuffix" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="NamedCredential">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="authProvider" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="certificate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="endpoint" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="oauthRefreshToken" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="oauthScope" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="oauthToken" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="password" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="principalType" type="tns:ExternalPrincipalType"/>
+       <xsd:element name="protocol" type="tns:AuthenticationProtocol"/>
+       <xsd:element name="username" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Network">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="allowMembersToFlag" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="branding" minOccurs="0" type="tns:Branding"/>
+       <xsd:element name="caseCommentEmailTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="changePasswordTemplate" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="emailSenderAddress" type="xsd:string"/>
+       <xsd:element name="emailSenderName" type="xsd:string"/>
+       <xsd:element name="enableGuestChatter" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableInvitation" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableKnowledgeable" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableNicknameDisplay" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enablePrivateMessages" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableReputation" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="feedChannel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="forgotPasswordTemplate" type="xsd:string"/>
+       <xsd:element name="logoutUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="networkMemberGroups" minOccurs="0" type="tns:NetworkMemberGroup"/>
+       <xsd:element name="newSenderAddress" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="picassoSite" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="reputationLevels" minOccurs="0" type="tns:ReputationLevelDefinitions"/>
+       <xsd:element name="reputationPointsRules" minOccurs="0" type="tns:ReputationPointsRules"/>
+       <xsd:element name="selfRegProfile" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="selfRegistration" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="sendWelcomeEmail" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="site" type="xsd:string"/>
+       <xsd:element name="status" type="tns:NetworkStatus"/>
+       <xsd:element name="tabs" type="tns:NetworkTabSet"/>
+       <xsd:element name="urlPathPrefix" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="welcomeTemplate" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Branding">
+    <xsd:sequence>
+     <xsd:element name="loginFooterText" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="loginLogo" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="pageFooter" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="pageHeader" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="primaryColor" type="xsd:string"/>
+     <xsd:element name="primaryComplementColor" type="xsd:string"/>
+     <xsd:element name="quaternaryColor" type="xsd:string"/>
+     <xsd:element name="quaternaryComplementColor" type="xsd:string"/>
+     <xsd:element name="secondaryColor" type="xsd:string"/>
+     <xsd:element name="tertiaryColor" type="xsd:string"/>
+     <xsd:element name="tertiaryComplementColor" type="xsd:string"/>
+     <xsd:element name="zeronaryColor" type="xsd:string"/>
+     <xsd:element name="zeronaryComplementColor" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="NetworkMemberGroup">
+    <xsd:sequence>
+     <xsd:element name="permissionSet" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="profile" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReputationLevelDefinitions">
+    <xsd:sequence>
+     <xsd:element name="level" minOccurs="0" maxOccurs="unbounded" type="tns:ReputationLevel"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReputationLevel">
+    <xsd:sequence>
+     <xsd:element name="branding" minOccurs="0" type="tns:ReputationBranding"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="lowerThreshold" type="xsd:double"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReputationBranding">
+    <xsd:sequence>
+     <xsd:element name="smallImage" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReputationPointsRules">
+    <xsd:sequence>
+     <xsd:element name="pointsRule" minOccurs="0" maxOccurs="unbounded" type="tns:ReputationPointsRule"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReputationPointsRule">
+    <xsd:sequence>
+     <xsd:element name="eventType" type="xsd:string"/>
+     <xsd:element name="points" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="NetworkStatus">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="UnderConstruction"/>
+     <xsd:enumeration value="Live"/>
+     <xsd:enumeration value="DownForMaintenance"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="NetworkTabSet">
+    <xsd:sequence>
+     <xsd:element name="customTab" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="defaultTab" type="xsd:string"/>
+     <xsd:element name="standardTab" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OpportunitySettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="autoActivateNewReminders" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableFindSimilarOpportunities" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableOpportunityTeam" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableUpdateReminders" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="findSimilarOppFilter" minOccurs="0" type="tns:FindSimilarOppFilter"/>
+       <xsd:element name="promptToAddProducts" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FindSimilarOppFilter">
+    <xsd:sequence>
+     <xsd:element name="similarOpportunitiesDisplayColumns" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="similarOpportunitiesMatchFields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableNegativeQuantity" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableOrders" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableReductionOrders" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Package">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="apiAccessLevel" minOccurs="0" type="tns:APIAccessLevel"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="namespacePrefix" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="objectPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileObjectPermissions"/>
+       <xsd:element name="postInstallClass" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="setupWeblink" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="types" minOccurs="0" maxOccurs="unbounded" type="tns:PackageTypeMembers"/>
+       <xsd:element name="uninstallClass" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="version" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="APIAccessLevel">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Unrestricted"/>
+     <xsd:enumeration value="Restricted"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ProfileObjectPermissions">
+    <xsd:sequence>
+     <xsd:element name="allowCreate" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="allowDelete" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="allowEdit" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="allowRead" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="modifyAllRecords" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="object" type="xsd:string"/>
+     <xsd:element name="viewAllRecords" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PackageTypeMembers">
+    <xsd:sequence>
+     <xsd:element name="members" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PathAssistant">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="entityName" type="xsd:string"/>
+       <xsd:element name="fieldName" type="xsd:string"/>
+       <xsd:element name="masterLabel" type="xsd:string"/>
+       <xsd:element name="pathAssistantSteps" minOccurs="0" maxOccurs="unbounded" type="tns:PathAssistantStep"/>
+       <xsd:element name="recordTypeName" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PathAssistantStep">
+    <xsd:sequence>
+     <xsd:element name="fieldNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="info" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="picklistValueName" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PathAssistantSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="pathAssistantForOpportunityEnabled" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSet">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="applicationVisibilities" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetApplicationVisibility"/>
+       <xsd:element name="classAccesses" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetApexClassAccess"/>
+       <xsd:element name="customPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetCustomPermissions"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="externalDataSourceAccesses" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetExternalDataSourceAccess"/>
+       <xsd:element name="fieldPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetFieldPermissions"/>
+       <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="objectPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetObjectPermissions"/>
+       <xsd:element name="pageAccesses" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetApexPageAccess"/>
+       <xsd:element name="recordTypeVisibilities" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetRecordTypeVisibility"/>
+       <xsd:element name="tabSettings" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetTabSetting"/>
+       <xsd:element name="userLicense" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="userPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:PermissionSetUserPermission"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetApplicationVisibility">
+    <xsd:sequence>
+     <xsd:element name="application" type="xsd:string"/>
+     <xsd:element name="visible" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetApexClassAccess">
+    <xsd:sequence>
+     <xsd:element name="apexClass" type="xsd:string"/>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetCustomPermissions">
+    <xsd:sequence>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetExternalDataSourceAccess">
+    <xsd:sequence>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+     <xsd:element name="externalDataSource" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetFieldPermissions">
+    <xsd:sequence>
+     <xsd:element name="editable" type="xsd:boolean"/>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="readable" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetObjectPermissions">
+    <xsd:sequence>
+     <xsd:element name="allowCreate" type="xsd:boolean"/>
+     <xsd:element name="allowDelete" type="xsd:boolean"/>
+     <xsd:element name="allowEdit" type="xsd:boolean"/>
+     <xsd:element name="allowRead" type="xsd:boolean"/>
+     <xsd:element name="modifyAllRecords" type="xsd:boolean"/>
+     <xsd:element name="object" type="xsd:string"/>
+     <xsd:element name="viewAllRecords" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetApexPageAccess">
+    <xsd:sequence>
+     <xsd:element name="apexPage" type="xsd:string"/>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetRecordTypeVisibility">
+    <xsd:sequence>
+     <xsd:element name="recordType" type="xsd:string"/>
+     <xsd:element name="visible" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PermissionSetTabSetting">
+    <xsd:sequence>
+     <xsd:element name="tab" type="xsd:string"/>
+     <xsd:element name="visibility" type="tns:PermissionSetTabVisibility"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="PermissionSetTabVisibility">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Available"/>
+     <xsd:enumeration value="Visible"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="PermissionSetUserPermission">
+    <xsd:sequence>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PersonListSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enablePersonList" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonalJourneySettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableExactTargetForSalesforceApps" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Portal">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="admin" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultLanguage" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="emailSenderAddress" type="xsd:string"/>
+       <xsd:element name="emailSenderName" type="xsd:string"/>
+       <xsd:element name="enableSelfCloseCase" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="footerDocument" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="forgotPassTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="headerDocument" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="isSelfRegistrationActivated" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="loginHeaderDocument" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="logoDocument" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="logoutUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="newCommentTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="newPassTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="newUserTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="ownerNotifyTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="selfRegNewUserUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="selfRegUserDefaultProfile" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="selfRegUserDefaultRole" minOccurs="0" type="tns:PortalRoles"/>
+       <xsd:element name="selfRegUserTemplate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="showActionConfirmation" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="stylesheetDocument" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="type" type="tns:PortalType"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="PortalRoles">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Executive"/>
+     <xsd:enumeration value="Manager"/>
+     <xsd:enumeration value="Worker"/>
+     <xsd:enumeration value="PersonAccount"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="PortalType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="CustomerSuccess"/>
+     <xsd:enumeration value="Partner"/>
+     <xsd:enumeration value="Network"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="PostTemplate">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="default" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProductSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableCascadeActivateToRelatedPrices" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableQuantitySchedule" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableRevenueSchedule" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Profile">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="applicationVisibilities" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileApplicationVisibility"/>
+       <xsd:element name="classAccesses" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileApexClassAccess"/>
+       <xsd:element name="custom" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="customPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileCustomPermissions"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="externalDataSourceAccesses" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileExternalDataSourceAccess"/>
+       <xsd:element name="fieldPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileFieldLevelSecurity"/>
+       <xsd:element name="layoutAssignments" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileLayoutAssignment"/>
+       <xsd:element name="loginHours" minOccurs="0" type="tns:ProfileLoginHours"/>
+       <xsd:element name="loginIpRanges" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileLoginIpRange"/>
+       <xsd:element name="objectPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileObjectPermissions"/>
+       <xsd:element name="pageAccesses" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileApexPageAccess"/>
+       <xsd:element name="recordTypeVisibilities" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileRecordTypeVisibility"/>
+       <xsd:element name="tabVisibilities" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileTabVisibility"/>
+       <xsd:element name="userLicense" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="userPermissions" minOccurs="0" maxOccurs="unbounded" type="tns:ProfileUserPermission"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileApplicationVisibility">
+    <xsd:sequence>
+     <xsd:element name="application" type="xsd:string"/>
+     <xsd:element name="default" type="xsd:boolean"/>
+     <xsd:element name="visible" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileApexClassAccess">
+    <xsd:sequence>
+     <xsd:element name="apexClass" type="xsd:string"/>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileCustomPermissions">
+    <xsd:sequence>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileExternalDataSourceAccess">
+    <xsd:sequence>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+     <xsd:element name="externalDataSource" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileFieldLevelSecurity">
+    <xsd:sequence>
+     <xsd:element name="editable" type="xsd:boolean"/>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="readable" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileLayoutAssignment">
+    <xsd:sequence>
+     <xsd:element name="layout" type="xsd:string"/>
+     <xsd:element name="recordType" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileLoginHours">
+    <xsd:sequence>
+     <xsd:element name="fridayEnd" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="fridayStart" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="mondayEnd" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="mondayStart" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="saturdayEnd" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="saturdayStart" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="sundayEnd" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="sundayStart" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="thursdayEnd" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="thursdayStart" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="tuesdayEnd" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="tuesdayStart" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="wednesdayEnd" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="wednesdayStart" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileLoginIpRange">
+    <xsd:sequence>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="endAddress" type="xsd:string"/>
+     <xsd:element name="startAddress" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileApexPageAccess">
+    <xsd:sequence>
+     <xsd:element name="apexPage" type="xsd:string"/>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileRecordTypeVisibility">
+    <xsd:sequence>
+     <xsd:element name="default" type="xsd:boolean"/>
+     <xsd:element name="personAccountDefault" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="recordType" type="xsd:string"/>
+     <xsd:element name="visible" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileTabVisibility">
+    <xsd:sequence>
+     <xsd:element name="tab" type="xsd:string"/>
+     <xsd:element name="visibility" type="tns:TabVisibility"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="TabVisibility">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Hidden"/>
+     <xsd:enumeration value="DefaultOff"/>
+     <xsd:enumeration value="DefaultOn"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ProfileUserPermission">
+    <xsd:sequence>
+     <xsd:element name="enabled" type="xsd:boolean"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Queue">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="doesSendEmailToMembers" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="email" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="queueSobject" minOccurs="0" maxOccurs="unbounded" type="tns:QueueSobject"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="QueueSobject">
+    <xsd:sequence>
+     <xsd:element name="sobjectType" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuickAction">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="canvas" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="fieldOverrides" minOccurs="0" maxOccurs="unbounded" type="tns:FieldOverride"/>
+       <xsd:element name="height" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="icon" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="isProtected" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="page" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="quickActionLayout" minOccurs="0" type="tns:QuickActionLayout"/>
+       <xsd:element name="standardLabel" minOccurs="0" type="tns:QuickActionLabel"/>
+       <xsd:element name="targetObject" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="targetParentField" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="targetRecordType" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="type" type="tns:QuickActionType"/>
+       <xsd:element name="width" minOccurs="0" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FieldOverride">
+    <xsd:sequence>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="formula" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="literalValue" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuickActionLayout">
+    <xsd:sequence>
+     <xsd:element name="layoutSectionStyle" type="tns:LayoutSectionStyle"/>
+     <xsd:element name="quickActionLayoutColumns" minOccurs="0" maxOccurs="unbounded" type="tns:QuickActionLayoutColumn"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuickActionLayoutColumn">
+    <xsd:sequence>
+     <xsd:element name="quickActionLayoutItems" minOccurs="0" maxOccurs="unbounded" type="tns:QuickActionLayoutItem"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuickActionLayoutItem">
+    <xsd:sequence>
+     <xsd:element name="emptySpace" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="field" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="uiBehavior" minOccurs="0" type="tns:UiBehavior"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="QuickActionLabel">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="LogACall"/>
+     <xsd:enumeration value="LogANote"/>
+     <xsd:enumeration value="New"/>
+     <xsd:enumeration value="NewRecordType"/>
+     <xsd:enumeration value="Update"/>
+     <xsd:enumeration value="NewChild"/>
+     <xsd:enumeration value="NewChildRecordType"/>
+     <xsd:enumeration value="CreateNew"/>
+     <xsd:enumeration value="CreateNewRecordType"/>
+     <xsd:enumeration value="SendEmail"/>
+     <xsd:enumeration value="QuickRecordType"/>
+     <xsd:enumeration value="Quick"/>
+     <xsd:enumeration value="EditDescription"/>
+     <xsd:enumeration value="Defer"/>
+     <xsd:enumeration value="ChangeDueDate"/>
+     <xsd:enumeration value="ChangePriority"/>
+     <xsd:enumeration value="ChangeStatus"/>
+     <xsd:enumeration value="SocialPost"/>
+     <xsd:enumeration value="Escalate"/>
+     <xsd:enumeration value="EscalateToRecord"/>
+     <xsd:enumeration value="OfferFeedback"/>
+     <xsd:enumeration value="RequestFeedback"/>
+     <xsd:enumeration value="AddRecord"/>
+     <xsd:enumeration value="AddMember"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="QuickActionType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Create"/>
+     <xsd:enumeration value="VisualforcePage"/>
+     <xsd:enumeration value="Post"/>
+     <xsd:enumeration value="SendEmail"/>
+     <xsd:enumeration value="LogACall"/>
+     <xsd:enumeration value="SocialPost"/>
+     <xsd:enumeration value="Canvas"/>
+     <xsd:enumeration value="Update"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="QuoteSettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="enableQuote" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="RemoteSiteSetting">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="disableProtocolSecurity" type="xsd:boolean"/>
+       <xsd:element name="isActive" type="xsd:boolean"/>
+       <xsd:element name="url" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Report">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="aggregates" minOccurs="0" maxOccurs="unbounded" type="tns:ReportAggregate"/>
+       <xsd:element name="block" minOccurs="0" maxOccurs="unbounded" type="tns:Report"/>
+       <xsd:element name="blockInfo" minOccurs="0" type="tns:ReportBlockInfo"/>
+       <xsd:element name="buckets" minOccurs="0" maxOccurs="unbounded" type="tns:ReportBucketField"/>
+       <xsd:element name="chart" minOccurs="0" type="tns:ReportChart"/>
+       <xsd:element name="colorRanges" minOccurs="0" maxOccurs="unbounded" type="tns:ReportColorRange"/>
+       <xsd:element name="columns" minOccurs="0" maxOccurs="unbounded" type="tns:ReportColumn"/>
+       <xsd:element name="crossFilters" minOccurs="0" maxOccurs="unbounded" type="tns:ReportCrossFilter"/>
+       <xsd:element name="currency" minOccurs="0" type="tns:CurrencyIsoCode"/>
+       <xsd:element name="dataCategoryFilters" minOccurs="0" maxOccurs="unbounded" type="tns:ReportDataCategoryFilter"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="division" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="filter" minOccurs="0" type="tns:ReportFilter"/>
+       <xsd:element name="format" type="tns:ReportFormat"/>
+       <xsd:element name="groupingsAcross" minOccurs="0" maxOccurs="unbounded" type="tns:ReportGrouping"/>
+       <xsd:element name="groupingsDown" minOccurs="0" maxOccurs="unbounded" type="tns:ReportGrouping"/>
+       <xsd:element name="historicalSelector" minOccurs="0" type="tns:ReportHistoricalSelector"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="params" minOccurs="0" maxOccurs="unbounded" type="tns:ReportParam"/>
+       <xsd:element name="reportType" type="xsd:string"/>
+       <xsd:element name="roleHierarchyFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="rowLimit" minOccurs="0" type="xsd:int"/>
+       <xsd:element name="scope" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="showCurrentDate" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="showDetails" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="sortColumn" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="sortOrder" minOccurs="0" type="tns:SortOrder"/>
+       <xsd:element name="territoryHierarchyFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="timeFrameFilter" minOccurs="0" type="tns:ReportTimeFrameFilter"/>
+       <xsd:element name="userFilter" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReportAggregate">
+    <xsd:sequence>
+     <xsd:element name="acrossGroupingContext" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="calculatedFormula" type="xsd:string"/>
+     <xsd:element name="datatype" type="tns:ReportAggregateDatatype"/>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="developerName" type="xsd:string"/>
+     <xsd:element name="downGroupingContext" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="isActive" type="xsd:boolean"/>
+     <xsd:element name="isCrossBlock" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="masterLabel" type="xsd:string"/>
+     <xsd:element name="reportType" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="scale" minOccurs="0" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ReportAggregateDatatype">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="currency"/>
+     <xsd:enumeration value="percent"/>
+     <xsd:enumeration value="number"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportBlockInfo">
+    <xsd:sequence>
+     <xsd:element name="aggregateReferences" minOccurs="0" maxOccurs="unbounded" type="tns:ReportAggregateReference"/>
+     <xsd:element name="blockId" type="xsd:string"/>
+     <xsd:element name="joinTable" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportAggregateReference">
+    <xsd:sequence>
+     <xsd:element name="aggregate" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportBucketField">
+    <xsd:sequence>
+     <xsd:element name="bucketType" type="tns:ReportBucketFieldType"/>
+     <xsd:element name="developerName" type="xsd:string"/>
+     <xsd:element name="masterLabel" type="xsd:string"/>
+     <xsd:element name="nullTreatment" minOccurs="0" type="tns:ReportFormulaNullTreatment"/>
+     <xsd:element name="otherBucketLabel" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="sourceColumnName" type="xsd:string"/>
+     <xsd:element name="useOther" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="values" minOccurs="0" maxOccurs="unbounded" type="tns:ReportBucketFieldValue"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ReportBucketFieldType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="text"/>
+     <xsd:enumeration value="number"/>
+     <xsd:enumeration value="picklist"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ReportFormulaNullTreatment">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="n"/>
+     <xsd:enumeration value="z"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportBucketFieldValue">
+    <xsd:sequence>
+     <xsd:element name="sourceValues" minOccurs="0" maxOccurs="unbounded" type="tns:ReportBucketFieldSourceValue"/>
+     <xsd:element name="value" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportBucketFieldSourceValue">
+    <xsd:sequence>
+     <xsd:element name="from" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="sourceValue" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="to" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportChart">
+    <xsd:sequence>
+     <xsd:element name="backgroundColor1" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="backgroundColor2" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="backgroundFadeDir" minOccurs="0" type="tns:ChartBackgroundDirection"/>
+     <xsd:element name="chartSummaries" minOccurs="0" maxOccurs="unbounded" type="tns:ChartSummary"/>
+     <xsd:element name="chartType" type="tns:ChartType"/>
+     <xsd:element name="enableHoverLabels" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="expandOthers" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="groupingColumn" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="legendPosition" minOccurs="0" type="tns:ChartLegendPosition"/>
+     <xsd:element name="location" minOccurs="0" type="tns:ChartPosition"/>
+     <xsd:element name="secondaryGroupingColumn" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="showAxisLabels" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showPercentage" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showTotal" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showValues" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="size" minOccurs="0" type="tns:ReportChartSize"/>
+     <xsd:element name="summaryAxisManualRangeEnd" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="summaryAxisManualRangeStart" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="summaryAxisRange" minOccurs="0" type="tns:ChartRangeType"/>
+     <xsd:element name="textColor" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="textSize" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="title" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="titleColor" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="titleSize" minOccurs="0" type="xsd:int"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ChartType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Scatter"/>
+     <xsd:enumeration value="ScatterGrouped"/>
+     <xsd:enumeration value="Bubble"/>
+     <xsd:enumeration value="BubbleGrouped"/>
+     <xsd:enumeration value="HorizontalBar"/>
+     <xsd:enumeration value="HorizontalBarGrouped"/>
+     <xsd:enumeration value="HorizontalBarStacked"/>
+     <xsd:enumeration value="HorizontalBarStackedTo100"/>
+     <xsd:enumeration value="VerticalColumn"/>
+     <xsd:enumeration value="VerticalColumnGrouped"/>
+     <xsd:enumeration value="VerticalColumnStacked"/>
+     <xsd:enumeration value="VerticalColumnStackedTo100"/>
+     <xsd:enumeration value="Line"/>
+     <xsd:enumeration value="LineGrouped"/>
+     <xsd:enumeration value="LineCumulative"/>
+     <xsd:enumeration value="LineCumulativeGrouped"/>
+     <xsd:enumeration value="Pie"/>
+     <xsd:enumeration value="Donut"/>
+     <xsd:enumeration value="Funnel"/>
+     <xsd:enumeration value="VerticalColumnLine"/>
+     <xsd:enumeration value="VerticalColumnGroupedLine"/>
+     <xsd:enumeration value="VerticalColumnStackedLine"/>
+     <xsd:enumeration value="Plugin"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ChartPosition">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="CHART_TOP"/>
+     <xsd:enumeration value="CHART_BOTTOM"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ReportChartSize">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Tiny"/>
+     <xsd:enumeration value="Small"/>
+     <xsd:enumeration value="Medium"/>
+     <xsd:enumeration value="Large"/>
+     <xsd:enumeration value="Huge"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportColorRange">
+    <xsd:sequence>
+     <xsd:element name="aggregate" minOccurs="0" type="tns:ReportSummaryType"/>
+     <xsd:element name="columnName" type="xsd:string"/>
+     <xsd:element name="highBreakpoint" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="highColor" type="xsd:string"/>
+     <xsd:element name="lowBreakpoint" minOccurs="0" type="xsd:double"/>
+     <xsd:element name="lowColor" type="xsd:string"/>
+     <xsd:element name="midColor" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportColumn">
+    <xsd:sequence>
+     <xsd:element name="aggregateTypes" minOccurs="0" maxOccurs="unbounded" type="tns:ReportSummaryType"/>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="reverseColors" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="showChanges" minOccurs="0" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportCrossFilter">
+    <xsd:sequence>
+     <xsd:element name="criteriaItems" minOccurs="0" maxOccurs="unbounded" type="tns:ReportFilterItem"/>
+     <xsd:element name="operation" type="tns:ObjectFilterOperator"/>
+     <xsd:element name="primaryTableColumn" type="xsd:string"/>
+     <xsd:element name="relatedTable" type="xsd:string"/>
+     <xsd:element name="relatedTableJoinColumn" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportFilterItem">
+    <xsd:sequence>
+     <xsd:element name="column" type="xsd:string"/>
+     <xsd:element name="columnToColumn" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="operator" type="tns:FilterOperation"/>
+     <xsd:element name="snapshot" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="value" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ObjectFilterOperator">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="with"/>
+     <xsd:enumeration value="without"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="CurrencyIsoCode">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="ADP"/>
+     <xsd:enumeration value="AED"/>
+     <xsd:enumeration value="AFA"/>
+     <xsd:enumeration value="AFN"/>
+     <xsd:enumeration value="ALL"/>
+     <xsd:enumeration value="AMD"/>
+     <xsd:enumeration value="ANG"/>
+     <xsd:enumeration value="AOA"/>
+     <xsd:enumeration value="ARS"/>
+     <xsd:enumeration value="ATS"/>
+     <xsd:enumeration value="AUD"/>
+     <xsd:enumeration value="AWG"/>
+     <xsd:enumeration value="AZM"/>
+     <xsd:enumeration value="AZN"/>
+     <xsd:enumeration value="BAM"/>
+     <xsd:enumeration value="BBD"/>
+     <xsd:enumeration value="BDT"/>
+     <xsd:enumeration value="BEF"/>
+     <xsd:enumeration value="BGL"/>
+     <xsd:enumeration value="BGN"/>
+     <xsd:enumeration value="BHD"/>
+     <xsd:enumeration value="BIF"/>
+     <xsd:enumeration value="BMD"/>
+     <xsd:enumeration value="BND"/>
+     <xsd:enumeration value="BOB"/>
+     <xsd:enumeration value="BOV"/>
+     <xsd:enumeration value="BRB"/>
+     <xsd:enumeration value="BRL"/>
+     <xsd:enumeration value="BSD"/>
+     <xsd:enumeration value="BTN"/>
+     <xsd:enumeration value="BWP"/>
+     <xsd:enumeration value="BYB"/>
+     <xsd:enumeration value="BYR"/>
+     <xsd:enumeration value="BZD"/>
+     <xsd:enumeration value="CAD"/>
+     <xsd:enumeration value="CDF"/>
+     <xsd:enumeration value="CHF"/>
+     <xsd:enumeration value="CLF"/>
+     <xsd:enumeration value="CLP"/>
+     <xsd:enumeration value="CNY"/>
+     <xsd:enumeration value="COP"/>
+     <xsd:enumeration value="CRC"/>
+     <xsd:enumeration value="CUP"/>
+     <xsd:enumeration value="CVE"/>
+     <xsd:enumeration value="CYP"/>
+     <xsd:enumeration value="CZK"/>
+     <xsd:enumeration value="DEM"/>
+     <xsd:enumeration value="DJF"/>
+     <xsd:enumeration value="DKK"/>
+     <xsd:enumeration value="DOP"/>
+     <xsd:enumeration value="DZD"/>
+     <xsd:enumeration value="ECS"/>
+     <xsd:enumeration value="EEK"/>
+     <xsd:enumeration value="EGP"/>
+     <xsd:enumeration value="ERN"/>
+     <xsd:enumeration value="ESP"/>
+     <xsd:enumeration value="ETB"/>
+     <xsd:enumeration value="EUR"/>
+     <xsd:enumeration value="FIM"/>
+     <xsd:enumeration value="FJD"/>
+     <xsd:enumeration value="FKP"/>
+     <xsd:enumeration value="FRF"/>
+     <xsd:enumeration value="GBP"/>
+     <xsd:enumeration value="GEL"/>
+     <xsd:enumeration value="GHC"/>
+     <xsd:enumeration value="GHS"/>
+     <xsd:enumeration value="GIP"/>
+     <xsd:enumeration value="GMD"/>
+     <xsd:enumeration value="GNF"/>
+     <xsd:enumeration value="GRD"/>
+     <xsd:enumeration value="GTQ"/>
+     <xsd:enumeration value="GWP"/>
+     <xsd:enumeration value="GYD"/>
+     <xsd:enumeration value="HKD"/>
+     <xsd:enumeration value="HNL"/>
+     <xsd:enumeration value="HRK"/>
+     <xsd:enumeration value="HTG"/>
+     <xsd:enumeration value="HUF"/>
+     <xsd:enumeration value="IDR"/>
+     <xsd:enumeration value="IEP"/>
+     <xsd:enumeration value="ILS"/>
+     <xsd:enumeration value="INR"/>
+     <xsd:enumeration value="IQD"/>
+     <xsd:enumeration value="IRR"/>
+     <xsd:enumeration value="ISK"/>
+     <xsd:enumeration value="ITL"/>
+     <xsd:enumeration value="JMD"/>
+     <xsd:enumeration value="JOD"/>
+     <xsd:enumeration value="JPY"/>
+     <xsd:enumeration value="KES"/>
+     <xsd:enumeration value="KGS"/>
+     <xsd:enumeration value="KHR"/>
+     <xsd:enumeration value="KMF"/>
+     <xsd:enumeration value="KPW"/>
+     <xsd:enumeration value="KRW"/>
+     <xsd:enumeration value="KWD"/>
+     <xsd:enumeration value="KYD"/>
+     <xsd:enumeration value="KZT"/>
+     <xsd:enumeration value="LAK"/>
+     <xsd:enumeration value="LBP"/>
+     <xsd:enumeration value="LKR"/>
+     <xsd:enumeration value="LRD"/>
+     <xsd:enumeration value="LSL"/>
+     <xsd:enumeration value="LTL"/>
+     <xsd:enumeration value="LUF"/>
+     <xsd:enumeration value="LVL"/>
+     <xsd:enumeration value="LYD"/>
+     <xsd:enumeration value="MAD"/>
+     <xsd:enumeration value="MDL"/>
+     <xsd:enumeration value="MGA"/>
+     <xsd:enumeration value="MGF"/>
+     <xsd:enumeration value="MKD"/>
+     <xsd:enumeration value="MMK"/>
+     <xsd:enumeration value="MNT"/>
+     <xsd:enumeration value="MOP"/>
+     <xsd:enumeration value="MRO"/>
+     <xsd:enumeration value="MTL"/>
+     <xsd:enumeration value="MUR"/>
+     <xsd:enumeration value="MVR"/>
+     <xsd:enumeration value="MWK"/>
+     <xsd:enumeration value="MXN"/>
+     <xsd:enumeration value="MXV"/>
+     <xsd:enumeration value="MYR"/>
+     <xsd:enumeration value="MZM"/>
+     <xsd:enumeration value="MZN"/>
+     <xsd:enumeration value="NAD"/>
+     <xsd:enumeration value="NGN"/>
+     <xsd:enumeration value="NIO"/>
+     <xsd:enumeration value="NLG"/>
+     <xsd:enumeration value="NOK"/>
+     <xsd:enumeration value="NPR"/>
+     <xsd:enumeration value="NZD"/>
+     <xsd:enumeration value="OMR"/>
+     <xsd:enumeration value="PAB"/>
+     <xsd:enumeration value="PEN"/>
+     <xsd:enumeration value="PGK"/>
+     <xsd:enumeration value="PHP"/>
+     <xsd:enumeration value="PKR"/>
+     <xsd:enumeration value="PLN"/>
+     <xsd:enumeration value="PTE"/>
+     <xsd:enumeration value="PYG"/>
+     <xsd:enumeration value="QAR"/>
+     <xsd:enumeration value="RMB"/>
+     <xsd:enumeration value="ROL"/>
+     <xsd:enumeration value="RON"/>
+     <xsd:enumeration value="RSD"/>
+     <xsd:enumeration value="RUB"/>
+     <xsd:enumeration value="RUR"/>
+     <xsd:enumeration value="RWF"/>
+     <xsd:enumeration value="SAR"/>
+     <xsd:enumeration value="SBD"/>
+     <xsd:enumeration value="SCR"/>
+     <xsd:enumeration value="SDD"/>
+     <xsd:enumeration value="SDG"/>
+     <xsd:enumeration value="SEK"/>
+     <xsd:enumeration value="SGD"/>
+     <xsd:enumeration value="SHP"/>
+     <xsd:enumeration value="SIT"/>
+     <xsd:enumeration value="SKK"/>
+     <xsd:enumeration value="SLL"/>
+     <xsd:enumeration value="SOS"/>
+     <xsd:enumeration value="SRD"/>
+     <xsd:enumeration value="SRG"/>
+     <xsd:enumeration value="SSP"/>
+     <xsd:enumeration value="STD"/>
+     <xsd:enumeration value="SVC"/>
+     <xsd:enumeration value="SYP"/>
+     <xsd:enumeration value="SZL"/>
+     <xsd:enumeration value="THB"/>
+     <xsd:enumeration value="TJR"/>
+     <xsd:enumeration value="TJS"/>
+     <xsd:enumeration value="TMM"/>
+     <xsd:enumeration value="TMT"/>
+     <xsd:enumeration value="TND"/>
+     <xsd:enumeration value="TOP"/>
+     <xsd:enumeration value="TPE"/>
+     <xsd:enumeration value="TRL"/>
+     <xsd:enumeration value="TRY"/>
+     <xsd:enumeration value="TTD"/>
+     <xsd:enumeration value="TWD"/>
+     <xsd:enumeration value="TZS"/>
+     <xsd:enumeration value="UAH"/>
+     <xsd:enumeration value="UGX"/>
+     <xsd:enumeration value="USD"/>
+     <xsd:enumeration value="UYU"/>
+     <xsd:enumeration value="UZS"/>
+     <xsd:enumeration value="VEB"/>
+     <xsd:enumeration value="VEF"/>
+     <xsd:enumeration value="VND"/>
+     <xsd:enumeration value="VUV"/>
+     <xsd:enumeration value="WST"/>
+     <xsd:enumeration value="XAF"/>
+     <xsd:enumeration value="XCD"/>
+     <xsd:enumeration value="XOF"/>
+     <xsd:enumeration value="XPF"/>
+     <xsd:enumeration value="YER"/>
+     <xsd:enumeration value="YUM"/>
+     <xsd:enumeration value="ZAR"/>
+     <xsd:enumeration value="ZMK"/>
+     <xsd:enumeration value="ZMW"/>
+     <xsd:enumeration value="ZWD"/>
+     <xsd:enumeration value="ZWL"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportDataCategoryFilter">
+    <xsd:sequence>
+     <xsd:element name="dataCategory" type="xsd:string"/>
+     <xsd:element name="dataCategoryGroup" type="xsd:string"/>
+     <xsd:element name="operator" type="tns:DataCategoryFilterOperation"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="DataCategoryFilterOperation">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="above"/>
+     <xsd:enumeration value="below"/>
+     <xsd:enumeration value="at"/>
+     <xsd:enumeration value="aboveOrBelow"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportFilter">
+    <xsd:sequence>
+     <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="criteriaItems" minOccurs="0" maxOccurs="unbounded" type="tns:ReportFilterItem"/>
+     <xsd:element name="language" minOccurs="0" type="tns:Language"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ReportFormat">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="MultiBlock"/>
+     <xsd:enumeration value="Matrix"/>
+     <xsd:enumeration value="Summary"/>
+     <xsd:enumeration value="Tabular"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportGrouping">
+    <xsd:sequence>
+     <xsd:element name="aggregateType" minOccurs="0" type="tns:ReportAggrType"/>
+     <xsd:element name="dateGranularity" minOccurs="0" type="tns:UserDateGranularity"/>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="sortByName" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="sortOrder" type="tns:SortOrder"/>
+     <xsd:element name="sortType" minOccurs="0" type="tns:ReportSortType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ReportAggrType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Sum"/>
+     <xsd:enumeration value="Average"/>
+     <xsd:enumeration value="Maximum"/>
+     <xsd:enumeration value="Minimum"/>
+     <xsd:enumeration value="RowCount"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="UserDateGranularity">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Day"/>
+     <xsd:enumeration value="Week"/>
+     <xsd:enumeration value="Month"/>
+     <xsd:enumeration value="Quarter"/>
+     <xsd:enumeration value="Year"/>
+     <xsd:enumeration value="FiscalQuarter"/>
+     <xsd:enumeration value="FiscalYear"/>
+     <xsd:enumeration value="MonthInYear"/>
+     <xsd:enumeration value="DayInMonth"/>
+     <xsd:enumeration value="FiscalPeriod"/>
+     <xsd:enumeration value="FiscalWeek"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ReportSortType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Column"/>
+     <xsd:enumeration value="Aggregate"/>
+     <xsd:enumeration value="CustomSummaryFormula"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportHistoricalSelector">
+    <xsd:sequence>
+     <xsd:element name="snapshot" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportParam">
+    <xsd:sequence>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="value" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTimeFrameFilter">
+    <xsd:sequence>
+     <xsd:element name="dateColumn" type="xsd:string"/>
+     <xsd:element name="endDate" minOccurs="0" type="xsd:date"/>
+     <xsd:element name="interval" type="tns:UserDateInterval"/>
+     <xsd:element name="startDate" minOccurs="0" type="xsd:date"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="UserDateInterval">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="INTERVAL_CURRENT"/>
+     <xsd:enumeration value="INTERVAL_CURNEXT1"/>
+     <xsd:enumeration value="INTERVAL_CURPREV1"/>
+     <xsd:enumeration value="INTERVAL_NEXT1"/>
+     <xsd:enumeration value="INTERVAL_PREV1"/>
+     <xsd:enumeration value="INTERVAL_CURNEXT3"/>
+     <xsd:enumeration value="INTERVAL_CURFY"/>
+     <xsd:enumeration value="INTERVAL_PREVFY"/>
+     <xsd:enumeration value="INTERVAL_PREV2FY"/>
+     <xsd:enumeration value="INTERVAL_AGO2FY"/>
+     <xsd:enumeration value="INTERVAL_NEXTFY"/>
+     <xsd:enumeration value="INTERVAL_PREVCURFY"/>
+     <xsd:enumeration value="INTERVAL_PREVCUR2FY"/>
+     <xsd:enumeration value="INTERVAL_CURNEXTFY"/>
+     <xsd:enumeration value="INTERVAL_CUSTOM"/>
+     <xsd:enumeration value="INTERVAL_YESTERDAY"/>
+     <xsd:enumeration value="INTERVAL_TODAY"/>
+     <xsd:enumeration value="INTERVAL_TOMORROW"/>
+     <xsd:enumeration value="INTERVAL_LASTWEEK"/>
+     <xsd:enumeration value="INTERVAL_THISWEEK"/>
+     <xsd:enumeration value="INTERVAL_NEXTWEEK"/>
+     <xsd:enumeration value="INTERVAL_LASTMONTH"/>
+     <xsd:enumeration value="INTERVAL_THISMONTH"/>
+     <xsd:enumeration value="INTERVAL_NEXTMONTH"/>
+     <xsd:enumeration value="INTERVAL_LASTTHISMONTH"/>
+     <xsd:enumeration value="INTERVAL_THISNEXTMONTH"/>
+     <xsd:enumeration value="INTERVAL_CURRENTQ"/>
+     <xsd:enumeration value="INTERVAL_CURNEXTQ"/>
+     <xsd:enumeration value="INTERVAL_CURPREVQ"/>
+     <xsd:enumeration value="INTERVAL_NEXTQ"/>
+     <xsd:enumeration value="INTERVAL_PREVQ"/>
+     <xsd:enumeration value="INTERVAL_CURNEXT3Q"/>
+     <xsd:enumeration value="INTERVAL_CURY"/>
+     <xsd:enumeration value="INTERVAL_PREVY"/>
+     <xsd:enumeration value="INTERVAL_PREV2Y"/>
+     <xsd:enumeration value="INTERVAL_AGO2Y"/>
+     <xsd:enumeration value="INTERVAL_NEXTY"/>
+     <xsd:enumeration value="INTERVAL_PREVCURY"/>
+     <xsd:enumeration value="INTERVAL_PREVCUR2Y"/>
+     <xsd:enumeration value="INTERVAL_CURNEXTY"/>
+     <xsd:enumeration value="INTERVAL_LAST7"/>
+     <xsd:enumeration value="INTERVAL_LAST30"/>
+     <xsd:enumeration value="INTERVAL_LAST60"/>
+     <xsd:enumeration value="INTERVAL_LAST90"/>
+     <xsd:enumeration value="INTERVAL_LAST120"/>
+     <xsd:enumeration value="INTERVAL_NEXT7"/>
+     <xsd:enumeration value="INTERVAL_NEXT30"/>
+     <xsd:enumeration value="INTERVAL_NEXT60"/>
+     <xsd:enumeration value="INTERVAL_NEXT90"/>
+     <xsd:enumeration value="INTERVAL_NEXT120"/>
+     <xsd:enumeration value="LAST_FISCALWEEK"/>
+     <xsd:enumeration value="THIS_FISCALWEEK"/>
+     <xsd:enumeration value="NEXT_FISCALWEEK"/>
+     <xsd:enumeration value="LAST_FISCALPERIOD"/>
+     <xsd:enumeration value="THIS_FISCALPERIOD"/>
+     <xsd:enumeration value="NEXT_FISCALPERIOD"/>
+     <xsd:enumeration value="LASTTHIS_FISCALPERIOD"/>
+     <xsd:enumeration value="THISNEXT_FISCALPERIOD"/>
+     <xsd:enumeration value="CURRENT_ENTITLEMENT_PERIOD"/>
+     <xsd:enumeration value="PREVIOUS_ENTITLEMENT_PERIOD"/>
+     <xsd:enumeration value="PREVIOUS_TWO_ENTITLEMENT_PERIODS"/>
+     <xsd:enumeration value="TWO_ENTITLEMENT_PERIODS_AGO"/>
+     <xsd:enumeration value="CURRENT_AND_PREVIOUS_ENTITLEMENT_PERIOD"/>
+     <xsd:enumeration value="CURRENT_AND_PREVIOUS_TWO_ENTITLEMENT_PERIODS"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ReportType">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="autogenerated" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="baseObject" type="xsd:string"/>
+       <xsd:element name="category" type="tns:ReportTypeCategory"/>
+       <xsd:element name="deployed" type="xsd:boolean"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="join" minOccurs="0" type="tns:ObjectRelationship"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="sections" minOccurs="0" maxOccurs="unbounded" type="tns:ReportLayoutSection"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="ReportTypeCategory">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="accounts"/>
+     <xsd:enumeration value="opportunities"/>
+     <xsd:enumeration value="forecasts"/>
+     <xsd:enumeration value="cases"/>
+     <xsd:enumeration value="leads"/>
+     <xsd:enumeration value="campaigns"/>
+     <xsd:enumeration value="activities"/>
+     <xsd:enumeration value="busop"/>
+     <xsd:enumeration value="products"/>
+     <xsd:enumeration value="admin"/>
+     <xsd:enumeration value="territory"/>
+     <xsd:enumeration value="other"/>
+     <xsd:enumeration value="content"/>
+     <xsd:enumeration value="usage_entitlement"/>
+     <xsd:enumeration value="wdc"/>
+     <xsd:enumeration value="calibration"/>
+     <xsd:enumeration value="territory2"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="ObjectRelationship">
+    <xsd:sequence>
+     <xsd:element name="join" minOccurs="0" type="tns:ObjectRelationship"/>
+     <xsd:element name="outerJoin" type="xsd:boolean"/>
+     <xsd:element name="relationship" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportLayoutSection">
+    <xsd:sequence>
+     <xsd:element name="columns" minOccurs="0" maxOccurs="unbounded" type="tns:ReportTypeColumn"/>
+     <xsd:element name="masterLabel" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTypeColumn">
+    <xsd:sequence>
+     <xsd:element name="checkedByDefault" type="xsd:boolean"/>
+     <xsd:element name="displayNameOverride" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="table" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RoleOrTerritory">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="caseAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="contactAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="mayForecastManagerShare" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="opportunityAccessLevel" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Role">
+    <xsd:complexContent>
+     <xsd:extension base="tns:RoleOrTerritory">
+      <xsd:sequence>
+       <xsd:element name="parentRole" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Territory">
+    <xsd:complexContent>
+     <xsd:extension base="tns:RoleOrTerritory">
+      <xsd:sequence>
+       <xsd:element name="accountAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="parentTerritory" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="SamlSsoConfig">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="attributeName" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="attributeNameIdFormat" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="decryptionCertificate" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="errorUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="executionUserId" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="identityLocation" type="tns:SamlIdentityLocationType"/>
+       <xsd:element name="identityMapping" type="tns:SamlIdentityType"/>
+       <xsd:element name="issuer" type="xsd:string"/>
+       <xsd:element name="loginUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="logoutUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="oauthTokenEndpoint" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="redirectBinding" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="requestSignatureMethod" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="salesforceLoginUrl" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="samlEntityId" type="xsd:string"/>
+       <xsd:element name="samlJitHandlerId" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="samlVersion" type="tns:SamlType"/>
+       <xsd:element name="userProvisioning" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="validationCert" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="SamlIdentityLocationType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="SubjectNameId"/>
+     <xsd:enumeration value="Attribute"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="SamlIdentityType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Username"/>
+     <xsd:enumeration value="FederationId"/>
+     <xsd:enumeration value="UserId"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="SamlType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="SAML1_1"/>
+     <xsd:enumeration value="SAML2_0"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="SecuritySettings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="networkAccess" minOccurs="0" type="tns:NetworkAccess"/>
+       <xsd:element name="passwordPolicies" minOccurs="0" type="tns:PasswordPolicies"/>
+       <xsd:element name="sessionSettings" minOccurs="0" type="tns:SessionSettings"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetworkAccess">
+    <xsd:sequence>
+     <xsd:element name="ipRanges" minOccurs="0" maxOccurs="unbounded" type="tns:IpRange"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="IpRange">
+    <xsd:sequence>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="end" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="start" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PasswordPolicies">
+    <xsd:sequence>
+     <xsd:element name="apiOnlyUserHomePageURL" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="complexity" minOccurs="0" type="tns:Complexity"/>
+     <xsd:element name="expiration" minOccurs="0" type="tns:Expiration"/>
+     <xsd:element name="historyRestriction" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="lockoutInterval" minOccurs="0" type="tns:LockoutInterval"/>
+     <xsd:element name="maxLoginAttempts" minOccurs="0" type="tns:MaxLoginAttempts"/>
+     <xsd:element name="minPasswordLength" minOccurs="0" type="tns:MinPasswordLength"/>
+     <xsd:element name="minimumPasswordLifetime" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="obscureSecretAnswer" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="passwordAssistanceMessage" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="passwordAssistanceURL" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="questionRestriction" minOccurs="0" type="tns:QuestionRestriction"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="Complexity">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="NoRestriction"/>
+     <xsd:enumeration value="AlphaNumeric"/>
+     <xsd:enumeration value="SpecialCharacters"/>
+     <xsd:enumeration value="UpperLowerCaseNumeric"/>
+     <xsd:enumeration value="UpperLowerCaseNumericSpecialCharacters"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="Expiration">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="ThirtyDays"/>
+     <xsd:enumeration value="SixtyDays"/>
+     <xsd:enumeration value="NinetyDays"/>
+     <xsd:enumeration value="SixMonths"/>
+     <xsd:enumeration value="OneYear"/>
+     <xsd:enumeration value="Never"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="LockoutInterval">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="FifteenMinutes"/>
+     <xsd:enumeration value="ThirtyMinutes"/>
+     <xsd:enumeration value="SixtyMinutes"/>
+     <xsd:enumeration value="Forever"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="MaxLoginAttempts">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="ThreeAttempts"/>
+     <xsd:enumeration value="FiveAttempts"/>
+     <xsd:enumeration value="TenAttempts"/>
+     <xsd:enumeration value="NoLimit"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="MinPasswordLength">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="FiveCharacters"/>
+     <xsd:enumeration value="EightCharacters"/>
+     <xsd:enumeration value="TenCharacters"/>
+     <xsd:enumeration value="TwelveCharacters"/>
+     <xsd:enumeration value="FifteenCharacters"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="QuestionRestriction">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="DoesNotContainPassword"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="SessionSettings">
+    <xsd:sequence>
+     <xsd:element name="disableTimeoutWarning" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableCSRFOnGet" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableCSRFOnPost" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableCacheAndAutocomplete" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableClickjackNonsetupSFDC" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableClickjackNonsetupUser" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableClickjackNonsetupUserHeaderless" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableClickjackSetup" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enablePostForSessions" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enableSMSIdentity" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="enforceIpRangesEveryRequest" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="forceLogoutOnSessionTimeout" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="forceRelogin" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="lockSessionsToDomain" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="lockSessionsToIp" minOccurs="0" type="xsd:boolean"/>
+     <xsd:element name="logoutURL" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="sessionTimeout" minOccurs="0" type="tns:SessionTimeout"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="SessionTimeout">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="TwelveHours"/>
+     <xsd:enumeration value="EightHours"/>
+     <xsd:enumeration value="FourHours"/>
+     <xsd:enumeration value="TwoHours"/>
+     <xsd:enumeration value="SixtyMinutes"/>
+     <xsd:enumeration value="ThirtyMinutes"/>
+     <xsd:enumeration value="FifteenMinutes"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="SharingBaseRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="accessLevel" type="xsd:string"/>
+       <xsd:element name="accountSettings" minOccurs="0" type="tns:AccountSharingRuleSettings"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="sharedTo" type="tns:SharedTo"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountSharingRuleSettings">
+    <xsd:sequence>
+     <xsd:element name="caseAccessLevel" type="xsd:string"/>
+     <xsd:element name="contactAccessLevel" type="xsd:string"/>
+     <xsd:element name="opportunityAccessLevel" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SharingCriteriaRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:SharingBaseRule">
+      <xsd:sequence>
+       <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="criteriaItems" minOccurs="0" maxOccurs="unbounded" type="tns:FilterItem"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="SharingOwnerRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:SharingBaseRule">
+      <xsd:sequence>
+       <xsd:element name="sharedFrom" type="tns:SharedTo"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="SharingTerritoryRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:SharingOwnerRule">
+      <xsd:sequence/>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="SharingRules">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="sharingCriteriaRules" minOccurs="0" maxOccurs="unbounded" type="tns:SharingCriteriaRule"/>
+       <xsd:element name="sharingOwnerRules" minOccurs="0" maxOccurs="unbounded" type="tns:SharingOwnerRule"/>
+       <xsd:element name="sharingTerritoryRules" minOccurs="0" maxOccurs="unbounded" type="tns:SharingTerritoryRule"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="SharingSet">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="accessMappings" minOccurs="0" maxOccurs="unbounded" type="tns:AccessMapping"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="profiles" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccessMapping">
+    <xsd:sequence>
+     <xsd:element name="accessLevel" type="xsd:string"/>
+     <xsd:element name="object" type="xsd:string"/>
+     <xsd:element name="objectField" type="xsd:string"/>
+     <xsd:element name="userField" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Skill">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="assignments" minOccurs="0" type="tns:SkillAssignments"/>
+       <xsd:element name="label" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="SkillAssignments">
+    <xsd:sequence>
+     <xsd:element name="profiles" minOccurs="0" type="tns:SkillProfileAssignments"/>
+     <xsd:element name="users" minOccurs="0" type="tns:SkillUserAssignments"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SkillProfileAssignments">
+    <xsd:sequence>
+     <xsd:element name="profile" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SkillUserAssignments">
+    <xsd:sequence>
+     <xsd:element name="user" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SynonymDictionary">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="groups" minOccurs="0" maxOccurs="unbounded" type="tns:SynonymGroup"/>
+       <xsd:element name="isProtected" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="label" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="SynonymGroup">
+    <xsd:sequence>
+     <xsd:element name="languages" minOccurs="0" maxOccurs="unbounded" type="tns:Language"/>
+     <xsd:element name="terms" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Territory2">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="accountAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="caseAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="contactAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="customFields" minOccurs="0" maxOccurs="unbounded" type="tns:FieldValue"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="opportunityAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="parentTerritory" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="ruleAssociations" minOccurs="0" maxOccurs="unbounded" type="tns:Territory2RuleAssociation"/>
+       <xsd:element name="territory2Type" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="FieldValue">
+    <xsd:sequence>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="value" type="xsd:anyType" nillable="true"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Territory2RuleAssociation">
+    <xsd:sequence>
+     <xsd:element name="inherited" type="xsd:boolean"/>
+     <xsd:element name="ruleName" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Territory2Model">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="customFields" minOccurs="0" maxOccurs="unbounded" type="tns:FieldValue"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Territory2Rule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="objectType" type="xsd:string"/>
+       <xsd:element name="ruleItems" minOccurs="0" maxOccurs="unbounded" type="tns:Territory2RuleItem"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Territory2RuleItem">
+    <xsd:sequence>
+     <xsd:element name="field" type="xsd:string"/>
+     <xsd:element name="operation" type="tns:FilterOperation"/>
+     <xsd:element name="value" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Territory2Settings">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="defaultAccountAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultCaseAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultContactAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="defaultOpportunityAccessLevel" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="opportunityFilterSettings" minOccurs="0" type="tns:Territory2SettingsOpportunityFilter"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Territory2SettingsOpportunityFilter">
+    <xsd:sequence>
+     <xsd:element name="apexClassName" type="xsd:string" nillable="true"/>
+     <xsd:element name="enableFilter" type="xsd:boolean"/>
+     <xsd:element name="runOnCreate" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Territory2Type">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="priority" type="xsd:int"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionSecurityPolicy">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="action" type="tns:Action"/>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="apexClass" type="xsd:string"/>
+       <xsd:element name="eventType" type="tns:MonitoredEvents"/>
+       <xsd:element name="resourceName" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="Action">
+    <xsd:sequence>
+     <xsd:element name="block" type="xsd:boolean"/>
+     <xsd:element name="endSession" type="xsd:boolean"/>
+     <xsd:element name="notifications" minOccurs="0" maxOccurs="unbounded" type="tns:Notification"/>
+     <xsd:element name="twoFactorAuthentication" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Notification">
+    <xsd:sequence>
+     <xsd:element name="inApp" type="xsd:boolean"/>
+     <xsd:element name="sendEmail" type="xsd:boolean"/>
+     <xsd:element name="user" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="MonitoredEvents">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="AuditTrail"/>
+     <xsd:enumeration value="Login"/>
+     <xsd:enumeration value="Entity"/>
+     <xsd:enumeration value="DataExport"/>
+     <xsd:enumeration value="AccessResource"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="Translations">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="customApplications" minOccurs="0" maxOccurs="unbounded" type="tns:CustomApplicationTranslation"/>
+       <xsd:element name="customDataTypeTranslations" minOccurs="0" maxOccurs="unbounded" type="tns:CustomDataTypeTranslation"/>
+       <xsd:element name="customLabels" minOccurs="0" maxOccurs="unbounded" type="tns:CustomLabelTranslation"/>
+       <xsd:element name="customPageWebLinks" minOccurs="0" maxOccurs="unbounded" type="tns:CustomPageWebLinkTranslation"/>
+       <xsd:element name="customTabs" minOccurs="0" maxOccurs="unbounded" type="tns:CustomTabTranslation"/>
+       <xsd:element name="quickActions" minOccurs="0" maxOccurs="unbounded" type="tns:GlobalQuickActionTranslation"/>
+       <xsd:element name="reportTypes" minOccurs="0" maxOccurs="unbounded" type="tns:ReportTypeTranslation"/>
+       <xsd:element name="scontrols" minOccurs="0" maxOccurs="unbounded" type="tns:ScontrolTranslation"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomApplicationTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomDataTypeTranslation">
+    <xsd:sequence>
+     <xsd:element name="components" minOccurs="0" maxOccurs="unbounded" type="tns:CustomDataTypeComponentTranslation"/>
+     <xsd:element name="customDataTypeName" type="xsd:string"/>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomDataTypeComponentTranslation">
+    <xsd:sequence>
+     <xsd:element name="developerSuffix" type="xsd:string"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomLabelTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomPageWebLinkTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomTabTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GlobalQuickActionTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTypeTranslation">
+    <xsd:sequence>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="sections" minOccurs="0" maxOccurs="unbounded" type="tns:ReportTypeSectionTranslation"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTypeSectionTranslation">
+    <xsd:sequence>
+     <xsd:element name="columns" minOccurs="0" maxOccurs="unbounded" type="tns:ReportTypeColumnTranslation"/>
+     <xsd:element name="label" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTypeColumnTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ScontrolTranslation">
+    <xsd:sequence>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="VisualizationPlugin">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="developerName" type="xsd:string"/>
+       <xsd:element name="icon" type="xsd:string"/>
+       <xsd:element name="masterLabel" type="xsd:string"/>
+       <xsd:element name="visualizationResources" minOccurs="0" maxOccurs="unbounded" type="tns:VisualizationResource"/>
+       <xsd:element name="visualizationTypes" minOccurs="0" maxOccurs="unbounded" type="tns:VisualizationType"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="VisualizationResource">
+    <xsd:sequence>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="file" type="xsd:string"/>
+     <xsd:element name="rank" minOccurs="0" type="xsd:int"/>
+     <xsd:element name="type" type="tns:VisualizationResourceType"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="VisualizationResourceType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="js"/>
+     <xsd:enumeration value="css"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="VisualizationType">
+    <xsd:sequence>
+     <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="developerName" type="xsd:string"/>
+     <xsd:element name="icon" type="xsd:string"/>
+     <xsd:element name="masterLabel" type="xsd:string"/>
+     <xsd:element name="scriptBootstrapMethod" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Workflow">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="alerts" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowAlert"/>
+       <xsd:element name="fieldUpdates" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowFieldUpdate"/>
+       <xsd:element name="flowActions" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowFlowAction"/>
+       <xsd:element name="knowledgePublishes" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowKnowledgePublish"/>
+       <xsd:element name="outboundMessages" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowOutboundMessage"/>
+       <xsd:element name="rules" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowRule"/>
+       <xsd:element name="send" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowSend"/>
+       <xsd:element name="tasks" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowTask"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkflowAlert">
+    <xsd:complexContent>
+     <xsd:extension base="tns:WorkflowAction">
+      <xsd:sequence>
+       <xsd:element name="ccEmails" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="description" type="xsd:string"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+       <xsd:element name="recipients" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowEmailRecipient"/>
+       <xsd:element name="senderAddress" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="senderType" minOccurs="0" type="tns:ActionEmailSenderType"/>
+       <xsd:element name="template" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkflowAction">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence/>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkflowFieldUpdate">
+    <xsd:complexContent>
+     <xsd:extension base="tns:WorkflowAction">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="field" type="xsd:string"/>
+       <xsd:element name="formula" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="literalValue" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="lookupValue" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="lookupValueType" minOccurs="0" type="tns:LookupValueType"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="notifyAssignee" type="xsd:boolean"/>
+       <xsd:element name="operation" type="tns:FieldUpdateOperation"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+       <xsd:element name="reevaluateOnChange" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="targetObject" minOccurs="0" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="LookupValueType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="User"/>
+     <xsd:enumeration value="Queue"/>
+     <xsd:enumeration value="RecordType"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="FieldUpdateOperation">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Formula"/>
+     <xsd:enumeration value="Literal"/>
+     <xsd:enumeration value="Null"/>
+     <xsd:enumeration value="NextValue"/>
+     <xsd:enumeration value="PreviousValue"/>
+     <xsd:enumeration value="LookupValue"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="WorkflowFlowAction">
+    <xsd:complexContent>
+     <xsd:extension base="tns:WorkflowAction">
+      <xsd:sequence>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="flow" type="xsd:string"/>
+       <xsd:element name="flowInputs" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowFlowActionParameter"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="language" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkflowFlowActionParameter">
+    <xsd:sequence>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="value" minOccurs="0" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WorkflowKnowledgePublish">
+    <xsd:complexContent>
+     <xsd:extension base="tns:WorkflowAction">
+      <xsd:sequence>
+       <xsd:element name="action" type="tns:KnowledgeWorkflowAction"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="language" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="KnowledgeWorkflowAction">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="PublishAsNew"/>
+     <xsd:enumeration value="Publish"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="WorkflowOutboundMessage">
+    <xsd:complexContent>
+     <xsd:extension base="tns:WorkflowAction">
+      <xsd:sequence>
+       <xsd:element name="apiVersion" type="xsd:double"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="endpointUrl" type="xsd:string"/>
+       <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="includeSessionId" type="xsd:boolean"/>
+       <xsd:element name="integrationUser" type="xsd:string"/>
+       <xsd:element name="name" type="xsd:string"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+       <xsd:element name="useDeadLetterQueue" minOccurs="0" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkflowSend">
+    <xsd:complexContent>
+     <xsd:extension base="tns:WorkflowAction">
+      <xsd:sequence>
+       <xsd:element name="action" type="tns:SendAction"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="language" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="SendAction">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Send"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="WorkflowTask">
+    <xsd:complexContent>
+     <xsd:extension base="tns:WorkflowAction">
+      <xsd:sequence>
+       <xsd:element name="assignedTo" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="assignedToType" type="tns:ActionTaskAssignedToTypes"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="dueDateOffset" type="xsd:int"/>
+       <xsd:element name="notifyAssignee" type="xsd:boolean"/>
+       <xsd:element name="offsetFromField" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="priority" type="xsd:string"/>
+       <xsd:element name="protected" type="xsd:boolean"/>
+       <xsd:element name="status" type="xsd:string"/>
+       <xsd:element name="subject" type="xsd:string"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="ActionTaskAssignedToTypes">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="user"/>
+     <xsd:enumeration value="role"/>
+     <xsd:enumeration value="opportunityTeam"/>
+     <xsd:enumeration value="accountTeam"/>
+     <xsd:enumeration value="owner"/>
+     <xsd:enumeration value="accountOwner"/>
+     <xsd:enumeration value="creator"/>
+     <xsd:enumeration value="accountCreator"/>
+     <xsd:enumeration value="partnerUser"/>
+     <xsd:enumeration value="portalRole"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="WorkflowEmailRecipient">
+    <xsd:sequence>
+     <xsd:element name="field" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="recipient" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="type" type="tns:ActionEmailRecipientTypes"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="ActionEmailRecipientTypes">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="group"/>
+     <xsd:enumeration value="role"/>
+     <xsd:enumeration value="user"/>
+     <xsd:enumeration value="opportunityTeam"/>
+     <xsd:enumeration value="accountTeam"/>
+     <xsd:enumeration value="roleSubordinates"/>
+     <xsd:enumeration value="owner"/>
+     <xsd:enumeration value="creator"/>
+     <xsd:enumeration value="partnerUser"/>
+     <xsd:enumeration value="accountOwner"/>
+     <xsd:enumeration value="customerPortalUser"/>
+     <xsd:enumeration value="portalRole"/>
+     <xsd:enumeration value="portalRoleSubordinates"/>
+     <xsd:enumeration value="contactLookup"/>
+     <xsd:enumeration value="userLookup"/>
+     <xsd:enumeration value="roleSubordinatesInternal"/>
+     <xsd:enumeration value="email"/>
+     <xsd:enumeration value="caseTeam"/>
+     <xsd:enumeration value="campaignMemberDerivedOwner"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="ActionEmailSenderType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="CurrentUser"/>
+     <xsd:enumeration value="OrgWideEmailAddress"/>
+     <xsd:enumeration value="DefaultWorkflowUser"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="WorkflowRule">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="actions" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowActionReference"/>
+       <xsd:element name="active" type="xsd:boolean"/>
+       <xsd:element name="booleanFilter" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="criteriaItems" minOccurs="0" maxOccurs="unbounded" type="tns:FilterItem"/>
+       <xsd:element name="description" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="formula" minOccurs="0" type="xsd:string"/>
+       <xsd:element name="triggerType" type="tns:WorkflowTriggerTypes"/>
+       <xsd:element name="workflowTimeTriggers" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowTimeTrigger"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:simpleType name="WorkflowTriggerTypes">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="onCreateOnly"/>
+     <xsd:enumeration value="onCreateOrTriggeringUpdate"/>
+     <xsd:enumeration value="onAllChanges"/>
+     <xsd:enumeration value="OnRecursiveUpdate"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="WorkflowTimeTrigger">
+    <xsd:sequence>
+     <xsd:element name="actions" minOccurs="0" maxOccurs="unbounded" type="tns:WorkflowActionReference"/>
+     <xsd:element name="offsetFromField" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="timeLength" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="workflowTimeTriggerUnit" type="tns:WorkflowTimeUnits"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="WorkflowTimeUnits">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Hours"/>
+     <xsd:enumeration value="Days"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="XOrgHub">
+    <xsd:complexContent>
+     <xsd:extension base="tns:Metadata">
+      <xsd:sequence>
+       <xsd:element name="label" type="xsd:string"/>
+       <xsd:element name="lockSharedObjects" type="xsd:boolean"/>
+       <xsd:element name="permissionSets" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+       <xsd:element name="sharedObjects" minOccurs="0" maxOccurs="unbounded" type="tns:XOrgHubSharedObject"/>
+      </xsd:sequence>
+     </xsd:extension>
+    </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="XOrgHubSharedObject">
+    <xsd:sequence>
+     <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SaveResult">
+    <xsd:sequence>
+     <xsd:element name="errors" minOccurs="0" maxOccurs="unbounded" type="tns:Error"/>
+     <xsd:element name="fullName" type="xsd:string"/>
+     <xsd:element name="success" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="Error">
+    <xsd:sequence>
+     <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="message" type="xsd:string"/>
+     <xsd:element name="statusCode" type="tns:StatusCode"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeleteResult">
+    <xsd:sequence>
+     <xsd:element name="errors" minOccurs="0" maxOccurs="unbounded" type="tns:Error"/>
+     <xsd:element name="fullName" type="xsd:string"/>
+     <xsd:element name="success" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeployOptions">
+    <xsd:sequence>
+     <xsd:element name="allowMissingFiles" type="xsd:boolean"/>
+     <xsd:element name="autoUpdatePackage" type="xsd:boolean"/>
+     <xsd:element name="checkOnly" type="xsd:boolean"/>
+     <xsd:element name="ignoreWarnings" type="xsd:boolean"/>
+     <xsd:element name="performRetrieve" type="xsd:boolean"/>
+     <xsd:element name="purgeOnDelete" type="xsd:boolean"/>
+     <xsd:element name="rollbackOnError" type="xsd:boolean"/>
+     <xsd:element name="runTests" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="singlePackage" type="xsd:boolean"/>
+     <xsd:element name="testLevel" type="tns:TestLevel"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="TestLevel">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="NoTestRun"/>
+     <xsd:enumeration value="RunSpecifiedTests"/>
+     <xsd:enumeration value="RunLocalTests"/>
+     <xsd:enumeration value="RunAllTestsInOrg"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="AsyncResult">
+    <xsd:sequence>
+     <xsd:element name="done" type="xsd:boolean"/>
+     <xsd:element name="id" type="tns:ID"/>
+     <xsd:element name="message" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="state" type="tns:AsyncRequestState"/>
+     <xsd:element name="statusCode" minOccurs="0" type="tns:StatusCode"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="AsyncRequestState">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Queued"/>
+     <xsd:enumeration value="InProgress"/>
+     <xsd:enumeration value="Completed"/>
+     <xsd:enumeration value="Error"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:complexType name="DescribeMetadataResult">
+    <xsd:sequence>
+     <xsd:element name="metadataObjects" minOccurs="0" maxOccurs="unbounded" type="tns:DescribeMetadataObject"/>
+     <xsd:element name="organizationNamespace" type="xsd:string"/>
+     <xsd:element name="partialSaveAllowed" type="xsd:boolean"/>
+     <xsd:element name="testRequired" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DescribeMetadataObject">
+    <xsd:sequence>
+     <xsd:element name="childXmlNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="directoryName" type="xsd:string"/>
+     <xsd:element name="inFolder" type="xsd:boolean"/>
+     <xsd:element name="metaFile" type="xsd:boolean"/>
+     <xsd:element name="suffix" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="xmlName" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DescribeValueTypeResult">
+    <xsd:sequence>
+     <xsd:element name="valueTypeFields" minOccurs="0" maxOccurs="unbounded" type="tns:ValueTypeField"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ValueTypeField">
+    <xsd:sequence>
+     <xsd:element name="fields" minOccurs="0" maxOccurs="unbounded" type="tns:ValueTypeField"/>
+     <xsd:element name="foreignKeyDomain" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="isForeignKey" type="xsd:boolean"/>
+     <xsd:element name="isNameField" type="xsd:boolean"/>
+     <xsd:element name="minOccurs" type="xsd:int"/>
+     <xsd:element name="name" type="xsd:string"/>
+     <xsd:element name="picklistValues" minOccurs="0" maxOccurs="unbounded" type="tns:PicklistEntry"/>
+     <xsd:element name="soapType" type="xsd:string"/>
+     <xsd:element name="valueRequired" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PicklistEntry">
+    <xsd:sequence>
+     <xsd:element name="active" type="xsd:boolean"/>
+     <xsd:element name="defaultValue" type="xsd:boolean"/>
+     <xsd:element name="label" type="xsd:string"/>
+     <xsd:element name="validFor" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="value" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ListMetadataQuery">
+    <xsd:sequence>
+     <xsd:element name="folder" minOccurs="0" type="xsd:string"/>
+     <xsd:element name="type" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReadResult">
+    <xsd:sequence>
+     <xsd:element name="records" minOccurs="0" maxOccurs="unbounded" type="tns:Metadata"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RetrieveRequest">
+    <xsd:sequence>
+     <xsd:element name="apiVersion" type="xsd:double"/>
+     <xsd:element name="packageNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="singlePackage" type="xsd:boolean"/>
+     <xsd:element name="specificFiles" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     <xsd:element name="unpackaged" minOccurs="0" type="tns:Package"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="UpsertResult">
+    <xsd:sequence>
+     <xsd:element name="created" type="xsd:boolean"/>
+     <xsd:element name="errors" minOccurs="0" maxOccurs="unbounded" type="tns:Error"/>
+     <xsd:element name="fullName" type="xsd:string"/>
+     <xsd:element name="success" type="xsd:boolean"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="AllOrNoneHeader">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="allOrNone" type="xsd:boolean"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="CallOptions">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="client" type="xsd:string"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="DebuggingHeader">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="categories" minOccurs="0" maxOccurs="unbounded" type="tns:LogInfo"/>
+      <xsd:element name="debugLevel" type="tns:LogType"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:complexType name="LogInfo">
+    <xsd:sequence>
+     <xsd:element name="category" type="tns:LogCategory"/>
+     <xsd:element name="level" type="tns:LogCategoryLevel"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:simpleType name="LogCategory">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Db"/>
+     <xsd:enumeration value="Workflow"/>
+     <xsd:enumeration value="Validation"/>
+     <xsd:enumeration value="Callout"/>
+     <xsd:enumeration value="Apex_code"/>
+     <xsd:enumeration value="Apex_profiling"/>
+     <xsd:enumeration value="Visualforce"/>
+     <xsd:enumeration value="System"/>
+     <xsd:enumeration value="All"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="LogCategoryLevel">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="Internal"/>
+     <xsd:enumeration value="Finest"/>
+     <xsd:enumeration value="Finer"/>
+     <xsd:enumeration value="Fine"/>
+     <xsd:enumeration value="Debug"/>
+     <xsd:enumeration value="Info"/>
+     <xsd:enumeration value="Warn"/>
+     <xsd:enumeration value="Error"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="LogType">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="None"/>
+     <xsd:enumeration value="Debugonly"/>
+     <xsd:enumeration value="Db"/>
+     <xsd:enumeration value="Profiling"/>
+     <xsd:enumeration value="Callout"/>
+     <xsd:enumeration value="Detail"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:element name="DebuggingInfo">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="debugLog" type="xsd:string"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="SessionHeader">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="sessionId" type="xsd:string"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:simpleType name="ID">
+    <xsd:restriction base="xsd:string">
+     <xsd:length value="18"/>
+     <xsd:pattern value="[a-zA-Z0-9]{18}"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:simpleType name="StatusCode">
+    <xsd:restriction base="xsd:string">
+     <xsd:enumeration value="ALL_OR_NONE_OPERATION_ROLLED_BACK"/>
+     <xsd:enumeration value="ALREADY_IN_PROCESS"/>
+     <xsd:enumeration value="ASSIGNEE_TYPE_REQUIRED"/>
+     <xsd:enumeration value="AURA_COMPILE_ERROR"/>
+     <xsd:enumeration value="BAD_CUSTOM_ENTITY_PARENT_DOMAIN"/>
+     <xsd:enumeration value="BCC_NOT_ALLOWED_IF_BCC_COMPLIANCE_ENABLED"/>
+     <xsd:enumeration value="CANNOT_CASCADE_PRODUCT_ACTIVE"/>
+     <xsd:enumeration value="CANNOT_CHANGE_FIELD_TYPE_OF_APEX_REFERENCED_FIELD"/>
+     <xsd:enumeration value="CANNOT_CHANGE_FIELD_TYPE_OF_REFERENCED_FIELD"/>
+     <xsd:enumeration value="CANNOT_CREATE_ANOTHER_MANAGED_PACKAGE"/>
+     <xsd:enumeration value="CANNOT_DEACTIVATE_DIVISION"/>
+     <xsd:enumeration value="CANNOT_DELETE_GLOBAL_ACTION_LIST"/>
+     <xsd:enumeration value="CANNOT_DELETE_LAST_DATED_CONVERSION_RATE"/>
+     <xsd:enumeration value="CANNOT_DELETE_MANAGED_OBJECT"/>
+     <xsd:enumeration value="CANNOT_DISABLE_LAST_ADMIN"/>
+     <xsd:enumeration value="CANNOT_ENABLE_IP_RESTRICT_REQUESTS"/>
+     <xsd:enumeration value="CANNOT_EXECUTE_FLOW_TRIGGER"/>
+     <xsd:enumeration value="CANNOT_FREEZE_SELF"/>
+     <xsd:enumeration value="CANNOT_INSERT_UPDATE_ACTIVATE_ENTITY"/>
+     <xsd:enumeration value="CANNOT_MODIFY_MANAGED_OBJECT"/>
+     <xsd:enumeration value="CANNOT_PASSWORD_LOCKOUT"/>
+     <xsd:enumeration value="CANNOT_POST_TO_ARCHIVED_GROUP"/>
+     <xsd:enumeration value="CANNOT_RENAME_APEX_REFERENCED_FIELD"/>
+     <xsd:enumeration value="CANNOT_RENAME_APEX_REFERENCED_OBJECT"/>
+     <xsd:enumeration value="CANNOT_RENAME_REFERENCED_FIELD"/>
+     <xsd:enumeration value="CANNOT_RENAME_REFERENCED_OBJECT"/>
+     <xsd:enumeration value="CANNOT_REPARENT_RECORD"/>
+     <xsd:enumeration value="CANNOT_UPDATE_CONVERTED_LEAD"/>
+     <xsd:enumeration value="CANT_DISABLE_CORP_CURRENCY"/>
+     <xsd:enumeration value="CANT_UNSET_CORP_CURRENCY"/>
+     <xsd:enumeration value="CHILD_SHARE_FAILS_PARENT"/>
+     <xsd:enumeration value="CIRCULAR_DEPENDENCY"/>
+     <xsd:enumeration value="CLEAN_SERVICE_ERROR"/>
+     <xsd:enumeration value="COLLISION_DETECTED"/>
+     <xsd:enumeration value="COMMUNITY_NOT_ACCESSIBLE"/>
+     <xsd:enumeration value="CONFLICTING_ENVIRONMENT_HUB_MEMBER"/>
+     <xsd:enumeration value="CONFLICTING_SSO_USER_MAPPING"/>
+     <xsd:enumeration value="CUSTOM_APEX_ERROR"/>
+     <xsd:enumeration value="CUSTOM_CLOB_FIELD_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="CUSTOM_ENTITY_OR_FIELD_LIMIT"/>
+     <xsd:enumeration value="CUSTOM_FIELD_INDEX_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="CUSTOM_INDEX_EXISTS"/>
+     <xsd:enumeration value="CUSTOM_LINK_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="CUSTOM_METADATA_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="CUSTOM_SETTINGS_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="CUSTOM_TAB_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="DATACLOUDADDRESS_NO_RECORDS_FOUND"/>
+     <xsd:enumeration value="DATACLOUDADDRESS_PROCESSING_ERROR"/>
+     <xsd:enumeration value="DATACLOUDADDRESS_SERVER_ERROR"/>
+     <xsd:enumeration value="DELETE_FAILED"/>
+     <xsd:enumeration value="DELETE_OPERATION_TOO_LARGE"/>
+     <xsd:enumeration value="DELETE_REQUIRED_ON_CASCADE"/>
+     <xsd:enumeration value="DEPENDENCY_EXISTS"/>
+     <xsd:enumeration value="DUPLICATES_DETECTED"/>
+     <xsd:enumeration value="DUPLICATE_CASE_SOLUTION"/>
+     <xsd:enumeration value="DUPLICATE_COMM_NICKNAME"/>
+     <xsd:enumeration value="DUPLICATE_CUSTOM_ENTITY_DEFINITION"/>
+     <xsd:enumeration value="DUPLICATE_CUSTOM_TAB_MOTIF"/>
+     <xsd:enumeration value="DUPLICATE_DEVELOPER_NAME"/>
+     <xsd:enumeration value="DUPLICATE_EXTERNAL_ID"/>
+     <xsd:enumeration value="DUPLICATE_MASTER_LABEL"/>
+     <xsd:enumeration value="DUPLICATE_SENDER_DISPLAY_NAME"/>
+     <xsd:enumeration value="DUPLICATE_USERNAME"/>
+     <xsd:enumeration value="DUPLICATE_VALUE"/>
+     <xsd:enumeration value="EMAIL_NOT_PROCESSED_DUE_TO_PRIOR_ERROR"/>
+     <xsd:enumeration value="EMPTY_SCONTROL_FILE_NAME"/>
+     <xsd:enumeration value="ENTITY_FAILED_IFLASTMODIFIED_ON_UPDATE"/>
+     <xsd:enumeration value="ENTITY_IS_ARCHIVED"/>
+     <xsd:enumeration value="ENTITY_IS_DELETED"/>
+     <xsd:enumeration value="ENTITY_IS_LOCKED"/>
+     <xsd:enumeration value="ENTITY_SAVE_ERROR"/>
+     <xsd:enumeration value="ENTITY_SAVE_VALIDATION_ERROR"/>
+     <xsd:enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_CONFLICT"/>
+     <xsd:enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_ERROR_JOINING_HUB"/>
+     <xsd:enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_USER_ALREADY_IN_HUB"/>
+     <xsd:enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_USER_NOT_ORG_ADMIN"/>
+     <xsd:enumeration value="ERROR_IN_MAILER"/>
+     <xsd:enumeration value="FAILED_ACTIVATION"/>
+     <xsd:enumeration value="FIELD_CUSTOM_VALIDATION_EXCEPTION"/>
+     <xsd:enumeration value="FIELD_FILTER_VALIDATION_EXCEPTION"/>
+     <xsd:enumeration value="FIELD_INTEGRITY_EXCEPTION"/>
+     <xsd:enumeration value="FIELD_NOT_UPDATABLE"/>
+     <xsd:enumeration value="FILTERED_LOOKUP_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="FIND_DUPLICATES_ERROR"/>
+     <xsd:enumeration value="HTML_FILE_UPLOAD_NOT_ALLOWED"/>
+     <xsd:enumeration value="IMAGE_TOO_LARGE"/>
+     <xsd:enumeration value="INACTIVE_OWNER_OR_USER"/>
+     <xsd:enumeration value="INACTIVE_RULE_ERROR"/>
+     <xsd:enumeration value="INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE"/>
+     <xsd:enumeration value="INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY"/>
+     <xsd:enumeration value="INSUFFICIENT_ACCESS_OR_READONLY"/>
+     <xsd:enumeration value="INSUFFICIENT_CREDITS"/>
+     <xsd:enumeration value="INVALID_ACCESS_LEVEL"/>
+     <xsd:enumeration value="INVALID_ARGUMENT_TYPE"/>
+     <xsd:enumeration value="INVALID_ASSIGNEE_TYPE"/>
+     <xsd:enumeration value="INVALID_ASSIGNMENT_RULE"/>
+     <xsd:enumeration value="INVALID_BATCH_OPERATION"/>
+     <xsd:enumeration value="INVALID_CONTENT_TYPE"/>
+     <xsd:enumeration value="INVALID_CREDIT_CARD_INFO"/>
+     <xsd:enumeration value="INVALID_CROSS_REFERENCE_KEY"/>
+     <xsd:enumeration value="INVALID_CROSS_REFERENCE_TYPE_FOR_FIELD"/>
+     <xsd:enumeration value="INVALID_CURRENCY_CONV_RATE"/>
+     <xsd:enumeration value="INVALID_CURRENCY_CORP_RATE"/>
+     <xsd:enumeration value="INVALID_CURRENCY_ISO"/>
+     <xsd:enumeration value="INVALID_DATA_CATEGORY_GROUP_REFERENCE"/>
+     <xsd:enumeration value="INVALID_DATA_URI"/>
+     <xsd:enumeration value="INVALID_EMAIL_ADDRESS"/>
+     <xsd:enumeration value="INVALID_EMPTY_KEY_OWNER"/>
+     <xsd:enumeration value="INVALID_ENTITY_FOR_MATCH_ENGINE_ERROR"/>
+     <xsd:enumeration value="INVALID_ENTITY_FOR_MATCH_OPERATION_ERROR"/>
+     <xsd:enumeration value="INVALID_ENVIRONMENT_HUB_MEMBER"/>
+     <xsd:enumeration value="INVALID_EVENT_PUBLICATION"/>
+     <xsd:enumeration value="INVALID_FIELD"/>
+     <xsd:enumeration value="INVALID_FIELD_FOR_INSERT_UPDATE"/>
+     <xsd:enumeration value="INVALID_FIELD_WHEN_USING_TEMPLATE"/>
+     <xsd:enumeration value="INVALID_FILTER_ACTION"/>
+     <xsd:enumeration value="INVALID_GOOGLE_DOCS_URL"/>
+     <xsd:enumeration value="INVALID_ID_FIELD"/>
+     <xsd:enumeration value="INVALID_INET_ADDRESS"/>
+     <xsd:enumeration value="INVALID_INPUT"/>
+     <xsd:enumeration value="INVALID_LINEITEM_CLONE_STATE"/>
+     <xsd:enumeration value="INVALID_MASTER_OR_TRANSLATED_SOLUTION"/>
+     <xsd:enumeration value="INVALID_MESSAGE_ID_REFERENCE"/>
+     <xsd:enumeration value="INVALID_OAUTH_URL"/>
+     <xsd:enumeration value="INVALID_OPERATION"/>
+     <xsd:enumeration value="INVALID_OPERATOR"/>
+     <xsd:enumeration value="INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST"/>
+     <xsd:enumeration value="INVALID_OWNER"/>
+     <xsd:enumeration value="INVALID_PACKAGE_LICENSE"/>
+     <xsd:enumeration value="INVALID_PACKAGE_VERSION"/>
+     <xsd:enumeration value="INVALID_PARTNER_NETWORK_STATUS"/>
+     <xsd:enumeration value="INVALID_PERSON_ACCOUNT_OPERATION"/>
+     <xsd:enumeration value="INVALID_QUERY_LOCATOR"/>
+     <xsd:enumeration value="INVALID_READ_ONLY_USER_DML"/>
+     <xsd:enumeration value="INVALID_RUNTIME_VALUE"/>
+     <xsd:enumeration value="INVALID_SAVE_AS_ACTIVITY_FLAG"/>
+     <xsd:enumeration value="INVALID_SESSION_ID"/>
+     <xsd:enumeration value="INVALID_SETUP_OWNER"/>
+     <xsd:enumeration value="INVALID_SIGNUP_COUNTRY"/>
+     <xsd:enumeration value="INVALID_SITE_DELETE_EXCEPTION"/>
+     <xsd:enumeration value="INVALID_SITE_FILE_IMPORTED_EXCEPTION"/>
+     <xsd:enumeration value="INVALID_SITE_FILE_TYPE_EXCEPTION"/>
+     <xsd:enumeration value="INVALID_STATUS"/>
+     <xsd:enumeration value="INVALID_SUBDOMAIN"/>
+     <xsd:enumeration value="INVALID_TYPE"/>
+     <xsd:enumeration value="INVALID_TYPE_FOR_OPERATION"/>
+     <xsd:enumeration value="INVALID_TYPE_ON_FIELD_IN_RECORD"/>
+     <xsd:enumeration value="INVALID_USERID"/>
+     <xsd:enumeration value="IP_RANGE_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="JIGSAW_IMPORT_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="LICENSE_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="LIGHT_PORTAL_USER_EXCEPTION"/>
+     <xsd:enumeration value="LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="MALFORMED_ID"/>
+     <xsd:enumeration value="MANAGER_NOT_DEFINED"/>
+     <xsd:enumeration value="MASSMAIL_RETRY_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="MASS_MAIL_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="MATCH_DEFINITION_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_INVALID_ENGINE_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_INVALID_RULE_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_MISSING_ENGINE_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_MISSING_OBJECT_TYPE_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_MISSING_OPTIONS_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_MISSING_RULE_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_UNKNOWN_RULE_ERROR"/>
+     <xsd:enumeration value="MATCH_OPERATION_UNSUPPORTED_VERSION_ERROR"/>
+     <xsd:enumeration value="MATCH_RUNTIME_ERROR"/>
+     <xsd:enumeration value="MATCH_SERVICE_ERROR"/>
+     <xsd:enumeration value="MATCH_SERVICE_TIMED_OUT"/>
+     <xsd:enumeration value="MATCH_SERVICE_UNAVAILABLE_ERROR"/>
+     <xsd:enumeration value="MAXIMUM_CCEMAILS_EXCEEDED"/>
+     <xsd:enumeration value="MAXIMUM_DASHBOARD_COMPONENTS_EXCEEDED"/>
+     <xsd:enumeration value="MAXIMUM_HIERARCHY_LEVELS_REACHED"/>
+     <xsd:enumeration value="MAXIMUM_SIZE_OF_ATTACHMENT"/>
+     <xsd:enumeration value="MAXIMUM_SIZE_OF_DOCUMENT"/>
+     <xsd:enumeration value="MAX_ACTIONS_PER_RULE_EXCEEDED"/>
+     <xsd:enumeration value="MAX_ACTIVE_RULES_EXCEEDED"/>
+     <xsd:enumeration value="MAX_APPROVAL_STEPS_EXCEEDED"/>
+     <xsd:enumeration value="MAX_FORMULAS_PER_RULE_EXCEEDED"/>
+     <xsd:enumeration value="MAX_RULES_EXCEEDED"/>
+     <xsd:enumeration value="MAX_RULE_ENTRIES_EXCEEDED"/>
+     <xsd:enumeration value="MAX_TASK_DESCRIPTION_EXCEEEDED"/>
+     <xsd:enumeration value="MAX_TM_RULES_EXCEEDED"/>
+     <xsd:enumeration value="MAX_TM_RULE_ITEMS_EXCEEDED"/>
+     <xsd:enumeration value="MERGE_FAILED"/>
+     <xsd:enumeration value="MISSING_ARGUMENT"/>
+     <xsd:enumeration value="MISSING_RECORD"/>
+     <xsd:enumeration value="MIXED_DML_OPERATION"/>
+     <xsd:enumeration value="NONUNIQUE_SHIPPING_ADDRESS"/>
+     <xsd:enumeration value="NO_APPLICABLE_PROCESS"/>
+     <xsd:enumeration value="NO_ATTACHMENT_PERMISSION"/>
+     <xsd:enumeration value="NO_INACTIVE_DIVISION_MEMBERS"/>
+     <xsd:enumeration value="NO_MASS_MAIL_PERMISSION"/>
+     <xsd:enumeration value="NO_SUCH_USER_EXISTS"/>
+     <xsd:enumeration value="NUMBER_OUTSIDE_VALID_RANGE"/>
+     <xsd:enumeration value="NUM_HISTORY_FIELDS_BY_SOBJECT_EXCEEDED"/>
+     <xsd:enumeration value="OPTED_OUT_OF_MASS_MAIL"/>
+     <xsd:enumeration value="OP_WITH_INVALID_USER_TYPE_EXCEPTION"/>
+     <xsd:enumeration value="PACKAGE_LICENSE_REQUIRED"/>
+     <xsd:enumeration value="PACKAGING_API_INSTALL_FAILED"/>
+     <xsd:enumeration value="PACKAGING_API_UNINSTALL_FAILED"/>
+     <xsd:enumeration value="PALI_INVALID_ACTION_ID"/>
+     <xsd:enumeration value="PALI_INVALID_ACTION_NAME"/>
+     <xsd:enumeration value="PALI_INVALID_ACTION_TYPE"/>
+     <xsd:enumeration value="PAL_INVALID_ENTITY_ID"/>
+     <xsd:enumeration value="PAL_INVALID_FLEXIPAGE_ID"/>
+     <xsd:enumeration value="PAL_INVALID_LAYOUT_ID"/>
+     <xsd:enumeration value="PAL_INVALID_PARAMETERS"/>
+     <xsd:enumeration value="PA_API_EXCEPTION"/>
+     <xsd:enumeration value="PA_AXIS_FAULT"/>
+     <xsd:enumeration value="PA_INVALID_ID_EXCEPTION"/>
+     <xsd:enumeration value="PA_NO_ACCESS_EXCEPTION"/>
+     <xsd:enumeration value="PA_NO_DATA_FOUND_EXCEPTION"/>
+     <xsd:enumeration value="PA_URI_SYNTAX_EXCEPTION"/>
+     <xsd:enumeration value="PA_VISIBLE_ACTIONS_FILTER_ORDERING_EXCEPTION"/>
+     <xsd:enumeration value="PORTAL_NO_ACCESS"/>
+     <xsd:enumeration value="PORTAL_USER_ALREADY_EXISTS_FOR_CONTACT"/>
+     <xsd:enumeration value="PRIVATE_CONTACT_ON_ASSET"/>
+     <xsd:enumeration value="QUERY_TIMEOUT"/>
+     <xsd:enumeration value="RECORD_IN_USE_BY_WORKFLOW"/>
+     <xsd:enumeration value="REPUTATION_MINIMUM_NUMBER_NOT_REACHED"/>
+     <xsd:enumeration value="REQUEST_RUNNING_TOO_LONG"/>
+     <xsd:enumeration value="REQUIRED_FEATURE_MISSING"/>
+     <xsd:enumeration value="REQUIRED_FIELD_MISSING"/>
+     <xsd:enumeration value="SELF_REFERENCE_FROM_FLOW"/>
+     <xsd:enumeration value="SELF_REFERENCE_FROM_TRIGGER"/>
+     <xsd:enumeration value="SHARE_NEEDED_FOR_CHILD_OWNER"/>
+     <xsd:enumeration value="SINGLE_EMAIL_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="STANDARD_PRICE_NOT_DEFINED"/>
+     <xsd:enumeration value="STORAGE_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="STRING_TOO_LONG"/>
+     <xsd:enumeration value="SUBDOMAIN_IN_USE"/>
+     <xsd:enumeration value="TABSET_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="TEMPLATE_NOT_ACTIVE"/>
+     <xsd:enumeration value="TEMPLATE_NOT_FOUND"/>
+     <xsd:enumeration value="TERRITORY_REALIGN_IN_PROGRESS"/>
+     <xsd:enumeration value="TEXT_DATA_OUTSIDE_SUPPORTED_CHARSET"/>
+     <xsd:enumeration value="TOO_MANY_APEX_REQUESTS"/>
+     <xsd:enumeration value="TOO_MANY_ENUM_VALUE"/>
+     <xsd:enumeration value="TOO_MANY_POSSIBLE_USERS_EXIST"/>
+     <xsd:enumeration value="TRANSFER_REQUIRES_READ"/>
+     <xsd:enumeration value="UNABLE_TO_LOCK_ROW"/>
+     <xsd:enumeration value="UNAVAILABLE_RECORDTYPE_EXCEPTION"/>
+     <xsd:enumeration value="UNDELETE_FAILED"/>
+     <xsd:enumeration value="UNKNOWN_EXCEPTION"/>
+     <xsd:enumeration value="UNSPECIFIED_EMAIL_ADDRESS"/>
+     <xsd:enumeration value="UNSUPPORTED_APEX_TRIGGER_OPERATON"/>
+     <xsd:enumeration value="UNVERIFIED_SENDER_ADDRESS"/>
+     <xsd:enumeration value="USER_OWNS_PORTAL_ACCOUNT_EXCEPTION"/>
+     <xsd:enumeration value="USER_WITH_APEX_SHARES_EXCEPTION"/>
+     <xsd:enumeration value="VF_COMPILE_ERROR"/>
+     <xsd:enumeration value="WEBLINK_SIZE_LIMIT_EXCEEDED"/>
+     <xsd:enumeration value="WEBLINK_URL_INVALID"/>
+     <xsd:enumeration value="WRONG_CONTROLLER_TYPE"/>
+     <xsd:enumeration value="XCLEAN_UNEXPECTED_ERROR"/>
+    </xsd:restriction>
+   </xsd:simpleType>
+   <xsd:element name="cancelDeploy">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="String" type="tns:ID"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="cancelDeployResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:CancelDeployResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="checkDeployStatus">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="asyncProcessId" type="tns:ID"/>
+      <xsd:element name="includeDetails" type="xsd:boolean"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="checkDeployStatusResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:DeployResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="checkRetrieveStatus">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="asyncProcessId" type="tns:ID"/>
+      <xsd:element name="includeZip" type="xsd:boolean"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="checkRetrieveStatusResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:RetrieveResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="createMetadata">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="metadata" minOccurs="0" maxOccurs="unbounded" type="tns:Metadata"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="createMetadataResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" minOccurs="0" maxOccurs="unbounded" type="tns:SaveResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="deleteMetadata">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="type" type="xsd:string"/>
+      <xsd:element name="fullNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="deleteMetadataResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" minOccurs="0" maxOccurs="unbounded" type="tns:DeleteResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="deploy">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="ZipFile" type="xsd:base64Binary"/>
+      <xsd:element name="DeployOptions" type="tns:DeployOptions"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="deployResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:AsyncResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="deployRecentValidation">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="validationId" type="tns:ID"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="deployRecentValidationResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="xsd:string"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="describeMetadata">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="asOfVersion" type="xsd:double"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="describeMetadataResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:DescribeMetadataResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="describeValueType">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="type" type="xsd:string"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="describeValueTypeResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:DescribeValueTypeResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="listMetadata">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="queries" minOccurs="0" maxOccurs="unbounded" type="tns:ListMetadataQuery"/>
+      <xsd:element name="asOfVersion" type="xsd:double"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="listMetadataResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" minOccurs="0" maxOccurs="unbounded" type="tns:FileProperties"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="readMetadata">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="type" type="xsd:string"/>
+      <xsd:element name="fullNames" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="readMetadataResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:ReadResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="renameMetadata">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="type" type="xsd:string"/>
+      <xsd:element name="oldFullName" type="xsd:string"/>
+      <xsd:element name="newFullName" type="xsd:string"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="renameMetadataResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:SaveResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="retrieve">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="retrieveRequest" type="tns:RetrieveRequest"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="retrieveResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" type="tns:AsyncResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="updateMetadata">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="metadata" minOccurs="0" maxOccurs="unbounded" type="tns:Metadata"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="updateMetadataResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" minOccurs="0" maxOccurs="unbounded" type="tns:SaveResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="upsertMetadata">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="metadata" minOccurs="0" maxOccurs="unbounded" type="tns:Metadata"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+   <xsd:element name="upsertMetadataResponse">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="result" minOccurs="0" maxOccurs="unbounded" type="tns:UpsertResult"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+  </xsd:schema>
+ </types>
+ <!-- Message for the header parts -->
+ <message name="Header">
+  <part name="AllOrNoneHeader" element="tns:AllOrNoneHeader"/>
+  <part name="CallOptions" element="tns:CallOptions"/>
+  <part name="DebuggingHeader" element="tns:DebuggingHeader"/>
+  <part name="DebuggingInfo" element="tns:DebuggingInfo"/>
+  <part name="SessionHeader" element="tns:SessionHeader"/>
+ </message>
+ <!-- Operation Messages -->
+ <message name="cancelDeployRequest">
+  <part element="tns:cancelDeploy" name="parameters"/>
+ </message>
+ <message name="cancelDeployResponse">
+  <part element="tns:cancelDeployResponse" name="parameters"/>
+ </message>
+ <message name="checkDeployStatusRequest">
+  <part element="tns:checkDeployStatus" name="parameters"/>
+ </message>
+ <message name="checkDeployStatusResponse">
+  <part element="tns:checkDeployStatusResponse" name="parameters"/>
+ </message>
+ <message name="checkRetrieveStatusRequest">
+  <part element="tns:checkRetrieveStatus" name="parameters"/>
+ </message>
+ <message name="checkRetrieveStatusResponse">
+  <part element="tns:checkRetrieveStatusResponse" name="parameters"/>
+ </message>
+ <message name="createMetadataRequest">
+  <part element="tns:createMetadata" name="parameters"/>
+ </message>
+ <message name="createMetadataResponse">
+  <part element="tns:createMetadataResponse" name="parameters"/>
+ </message>
+ <message name="deleteMetadataRequest">
+  <part element="tns:deleteMetadata" name="parameters"/>
+ </message>
+ <message name="deleteMetadataResponse">
+  <part element="tns:deleteMetadataResponse" name="parameters"/>
+ </message>
+ <message name="deployRequest">
+  <part element="tns:deploy" name="parameters"/>
+ </message>
+ <message name="deployResponse">
+  <part element="tns:deployResponse" name="parameters"/>
+ </message>
+ <message name="deployRecentValidationRequest">
+  <part element="tns:deployRecentValidation" name="parameters"/>
+ </message>
+ <message name="deployRecentValidationResponse">
+  <part element="tns:deployRecentValidationResponse" name="parameters"/>
+ </message>
+ <message name="describeMetadataRequest">
+  <part element="tns:describeMetadata" name="parameters"/>
+ </message>
+ <message name="describeMetadataResponse">
+  <part element="tns:describeMetadataResponse" name="parameters"/>
+ </message>
+ <message name="describeValueTypeRequest">
+  <part element="tns:describeValueType" name="parameters"/>
+ </message>
+ <message name="describeValueTypeResponse">
+  <part element="tns:describeValueTypeResponse" name="parameters"/>
+ </message>
+ <message name="listMetadataRequest">
+  <part element="tns:listMetadata" name="parameters"/>
+ </message>
+ <message name="listMetadataResponse">
+  <part element="tns:listMetadataResponse" name="parameters"/>
+ </message>
+ <message name="readMetadataRequest">
+  <part element="tns:readMetadata" name="parameters"/>
+ </message>
+ <message name="readMetadataResponse">
+  <part element="tns:readMetadataResponse" name="parameters"/>
+ </message>
+ <message name="renameMetadataRequest">
+  <part element="tns:renameMetadata" name="parameters"/>
+ </message>
+ <message name="renameMetadataResponse">
+  <part element="tns:renameMetadataResponse" name="parameters"/>
+ </message>
+ <message name="retrieveRequest">
+  <part element="tns:retrieve" name="parameters"/>
+ </message>
+ <message name="retrieveResponse">
+  <part element="tns:retrieveResponse" name="parameters"/>
+ </message>
+ <message name="updateMetadataRequest">
+  <part element="tns:updateMetadata" name="parameters"/>
+ </message>
+ <message name="updateMetadataResponse">
+  <part element="tns:updateMetadataResponse" name="parameters"/>
+ </message>
+ <message name="upsertMetadataRequest">
+  <part element="tns:upsertMetadata" name="parameters"/>
+ </message>
+ <message name="upsertMetadataResponse">
+  <part element="tns:upsertMetadataResponse" name="parameters"/>
+ </message>
+ <portType name="MetadataPortType">
+  <operation name="cancelDeploy">
+   <documentation>Cancels a metadata deploy.</documentation>
+   <input message="tns:cancelDeployRequest"/>
+   <output message="tns:cancelDeployResponse"/>
+  </operation>
+  <operation name="checkDeployStatus">
+   <documentation>Check the current status of an asyncronous deploy call.</documentation>
+   <input message="tns:checkDeployStatusRequest"/>
+   <output message="tns:checkDeployStatusResponse"/>
+  </operation>
+  <operation name="checkRetrieveStatus">
+   <documentation>Check the current status of an asyncronous deploy call.</documentation>
+   <input message="tns:checkRetrieveStatusRequest"/>
+   <output message="tns:checkRetrieveStatusResponse"/>
+  </operation>
+  <operation name="createMetadata">
+   <documentation>Creates metadata entries synchronously.</documentation>
+   <input message="tns:createMetadataRequest"/>
+   <output message="tns:createMetadataResponse"/>
+  </operation>
+  <operation name="deleteMetadata">
+   <documentation>Deletes metadata entries synchronously.</documentation>
+   <input message="tns:deleteMetadataRequest"/>
+   <output message="tns:deleteMetadataResponse"/>
+  </operation>
+  <operation name="deploy">
+   <documentation>Deploys a zipfile full of metadata entries asynchronously.</documentation>
+   <input message="tns:deployRequest"/>
+   <output message="tns:deployResponse"/>
+  </operation>
+  <operation name="deployRecentValidation">
+   <documentation>Deploys a previously validated payload without running tests.</documentation>
+   <input message="tns:deployRecentValidationRequest"/>
+   <output message="tns:deployRecentValidationResponse"/>
+  </operation>
+  <operation name="describeMetadata">
+   <documentation>Describes features of the metadata API.</documentation>
+   <input message="tns:describeMetadataRequest"/>
+   <output message="tns:describeMetadataResponse"/>
+  </operation>
+  <operation name="describeValueType">
+   <documentation>Describe a complex value type</documentation>
+   <input message="tns:describeValueTypeRequest"/>
+   <output message="tns:describeValueTypeResponse"/>
+  </operation>
+  <operation name="listMetadata">
+   <documentation>Lists the available metadata components.</documentation>
+   <input message="tns:listMetadataRequest"/>
+   <output message="tns:listMetadataResponse"/>
+  </operation>
+  <operation name="readMetadata">
+   <documentation>Reads metadata entries synchronously.</documentation>
+   <input message="tns:readMetadataRequest"/>
+   <output message="tns:readMetadataResponse"/>
+  </operation>
+  <operation name="renameMetadata">
+   <documentation>Renames a metadata entry synchronously.</documentation>
+   <input message="tns:renameMetadataRequest"/>
+   <output message="tns:renameMetadataResponse"/>
+  </operation>
+  <operation name="retrieve">
+   <documentation>Retrieves a set of individually specified metadata entries.</documentation>
+   <input message="tns:retrieveRequest"/>
+   <output message="tns:retrieveResponse"/>
+  </operation>
+  <operation name="updateMetadata">
+   <documentation>Updates metadata entries synchronously.</documentation>
+   <input message="tns:updateMetadataRequest"/>
+   <output message="tns:updateMetadataResponse"/>
+  </operation>
+  <operation name="upsertMetadata">
+   <documentation>Upserts metadata entries synchronously.</documentation>
+   <input message="tns:upsertMetadataRequest"/>
+   <output message="tns:upsertMetadataResponse"/>
+  </operation>
+ </portType>
+ <binding name="MetadataBinding" type="tns:MetadataPortType">
+  <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+  <operation name="cancelDeploy">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="checkDeployStatus">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:header use="literal" part="DebuggingInfo" message="tns:Header"/>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="checkRetrieveStatus">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="createMetadata">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:header use="literal" part="AllOrNoneHeader" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="deleteMetadata">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:header use="literal" part="AllOrNoneHeader" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="deploy">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="DebuggingHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="deployRecentValidation">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="DebuggingHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="describeMetadata">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="describeValueType">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="listMetadata">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="readMetadata">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="renameMetadata">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="retrieve">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="updateMetadata">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:header use="literal" part="AllOrNoneHeader" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+  <operation name="upsertMetadata">
+   <soap:operation soapAction=""/>
+   <input>
+    <soap:header use="literal" part="SessionHeader" message="tns:Header"/>
+    <soap:header use="literal" part="CallOptions" message="tns:Header"/>
+    <soap:header use="literal" part="AllOrNoneHeader" message="tns:Header"/>
+    <soap:body use="literal" parts="parameters"/>
+   </input>
+   <output>
+    <soap:body use="literal"/>
+   </output>
+  </operation>
+ </binding>
+ <service name="MetadataService">
+  <documentation>Manage your Salesforce.com metadata</documentation>
+  <port binding="tns:MetadataBinding" name="Metadata">
+   <soap:address location="https://login.salesforce.com/services/Soap/m/34.0"/>
+  </port>
+ </service>
+</definitions>

--- a/wsdl/34.0/partner.xml
+++ b/wsdl/34.0/partner.xml
@@ -1,0 +1,5405 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Salesforce.com Partner Web Services API Version 34.0
+Generated on 2015-06-26 17:02:32 +0000.
+
+Copyright 1999-2015 salesforce.com, inc.
+All Rights Reserved
+-->
+
+<definitions targetNamespace="urn:partner.soap.sforce.com"
+             xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:fns="urn:fault.partner.soap.sforce.com"
+             xmlns:tns="urn:partner.soap.sforce.com"
+             xmlns:ens="urn:sobject.partner.soap.sforce.com">
+    <types>
+
+        <schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:sobject.partner.soap.sforce.com">
+
+            <import namespace="urn:partner.soap.sforce.com"/>
+
+
+            <!-- Dynamic sObject -->
+            <complexType name="sObject">
+                <sequence>
+                    <element name="type"               type="xsd:string"/>
+                    <element name="fieldsToNull"       type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="Id"                 type="tns:ID" nillable="true" />
+                    <any namespace="##targetNamespace" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+                </sequence>
+            </complexType>
+
+        </schema>
+
+        <schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:partner.soap.sforce.com">
+
+            <import namespace="urn:sobject.partner.soap.sforce.com"/>
+
+            <!-- Our simple ID Type -->
+            <simpleType name="ID">
+                <restriction base="xsd:string">
+                    <length value="18"/>
+                    <pattern value='[a-zA-Z0-9]{18}'/>
+                </restriction>
+            </simpleType>
+
+            <!-- Compound datatype: Address -->
+            <complexType name="address">
+                <complexContent>
+                    <extension base="tns:location">
+                        <sequence>
+                            <element name="city" type="xsd:string"  nillable="true" />
+                            <element name="country" type="xsd:string"  nillable="true" />
+                            <element name="countryCode" type="xsd:string"  nillable="true" />
+                            <element name="postalCode" type="xsd:string"  nillable="true" />
+                            <element name="state" type="xsd:string"  nillable="true" />
+                            <element name="stateCode" type="xsd:string"  nillable="true" />
+                            <element name="street" type="xsd:string"  nillable="true" />
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <!-- Compound datatype: Location -->
+            <complexType name="location">
+                <sequence>
+                    <element name="latitude" type="xsd:double"  nillable="true" />
+                    <element name="longitude" type="xsd:double"  nillable="true" />
+                </sequence>
+            </complexType>
+
+            
+            <simpleType name="QueryLocator">
+                <restriction base="xsd:string"/>
+            </simpleType>
+
+            <!-- Shared Result Types -->
+            <complexType name="QueryResult">
+                <sequence>
+                    <element name="done"         type="xsd:boolean"/>
+                    <element name="queryLocator" type="tns:QueryLocator" nillable="true"/>
+                    <element name="records"      type="ens:sObject" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="size"         type="xsd:int"/>
+                </sequence>
+            </complexType>
+
+
+
+            <!-- Search Result -->
+            <complexType name="SearchResult">
+                <sequence>
+                    
+                        <element name="queryId" type="xsd:string" nillable="false" minOccurs="1" maxOccurs="1"/>
+                    
+                    <element name="searchRecords" minOccurs="0" maxOccurs="unbounded" type="tns:SearchRecord"/>
+                    
+                </sequence>
+            </complexType>
+
+            <complexType name="SearchRecord">
+                <sequence>
+                    <element name="record" type="ens:sObject"/>
+                    <element name="snippet" nillable="true" minOccurs="0" maxOccurs="1" type="tns:SearchSnippet"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="SearchSnippet">
+                <sequence>
+                    <element name="text" nillable="true" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+                    <element name="wholeFields" minOccurs="0" maxOccurs="unbounded" type="tns:NameValuePair"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="RelationshipReferenceTo">
+                <sequence>
+                    <element name="referenceTo" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <!-- Common name-value pair -->
+            <complexType name="NameValuePair">
+                <sequence>
+                    <element name="name" type="xsd:string" />
+                    <element name="value" type="xsd:string" />
+                </sequence>
+            </complexType>
+
+            <!-- GetUpdated Result -->
+            <complexType name="GetUpdatedResult">
+                <sequence>
+                    <element name="ids" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
+                    <element name="latestDateCovered" type="xsd:dateTime"/>
+                    
+                </sequence>
+            </complexType>
+
+            <!-- GetDeleted Result -->
+            <complexType name="GetDeletedResult">
+                <sequence>
+                    <element name="deletedRecords" minOccurs="0" maxOccurs="unbounded" type="tns:DeletedRecord"/>
+                    <element name="earliestDateAvailable" type="xsd:dateTime"/>
+                    <element name="latestDateCovered" type="xsd:dateTime"/>
+                    
+                </sequence>
+            </complexType>
+
+            <complexType name="DeletedRecord">
+                <sequence>
+                    <element name="deletedDate" type="xsd:dateTime"/>
+                    <element name="id"          type="tns:ID"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="GetServerTimestampResult">
+                <sequence>
+                    <element name="timestamp" type="xsd:dateTime"/>
+                </sequence>
+            </complexType>
+
+
+            <!-- InvalidateSessions Result -->
+            <complexType name="InvalidateSessionsResult">
+                <sequence>
+                    <element name="errors"  type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="success"   type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="SetPasswordResult">
+            </complexType>
+
+            <complexType name="ResetPasswordResult">
+                <sequence>
+                    <element name="password" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="GetUserInfoResult">
+                <sequence>
+                    <element name="accessibilityMode"          type="xsd:boolean"/>
+                    <element name="currencySymbol"             type="xsd:string" nillable="true"/>
+                    <element name="orgAttachmentFileSizeLimit" type="xsd:int"/>
+                    <element name="orgDefaultCurrencyIsoCode"  type="xsd:string" nillable="true"/>
+                    <element name="orgDisallowHtmlAttachments" type="xsd:boolean"/>
+                    <element name="orgHasPersonAccounts"       type="xsd:boolean"/>
+                    <element name="organizationId"             type="tns:ID"/>
+                    <element name="organizationMultiCurrency"  type="xsd:boolean"/>
+                    <element name="organizationName"           type="xsd:string"/>
+                    <element name="profileId"                  type="tns:ID"/>
+                    <element name="roleId"                     type="tns:ID" nillable="true"/>
+                    <element name="sessionSecondsValid"        type="xsd:int"/>
+                    <element name="userDefaultCurrencyIsoCode" type="xsd:string" nillable="true"/>
+                    <element name="userEmail"                  type="xsd:string"/>
+                    <element name="userFullName"               type="xsd:string"/>
+                    <element name="userId"                     type="tns:ID"/>
+                    <element name="userLanguage"               type="xsd:string"/>
+                    <element name="userLocale"                 type="xsd:string"/>
+                    <element name="userName"                   type="xsd:string"/>
+                    <element name="userTimeZone"               type="xsd:string"/>
+                    <element name="userType"                   type="xsd:string"/>
+                    <element name="userUiSkin"                 type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="LoginResult">
+                <sequence>
+                    <element name="metadataServerUrl" type="xsd:string" nillable="true"/>
+                    <element name="passwordExpired"   type="xsd:boolean" />
+                    <element name="sandbox"      type="xsd:boolean"/>
+                    <element name="serverUrl"         type="xsd:string" nillable="true"/>
+                    <element name="sessionId"         type="xsd:string" nillable="true"/>
+
+                    <element name="userId"           type="tns:ID" nillable="true"/>
+                    <element name="userInfo"         type="tns:GetUserInfoResult" minOccurs="0"/>
+                </sequence>
+            </complexType>
+
+
+            <simpleType name="StatusCode">
+                <restriction base="xsd:string">
+                    <enumeration value="ALL_OR_NONE_OPERATION_ROLLED_BACK"/>
+                    <enumeration value="ALREADY_IN_PROCESS"/>
+                    <enumeration value="ASSIGNEE_TYPE_REQUIRED"/>
+                    <enumeration value="AURA_COMPILE_ERROR"/>
+                    <enumeration value="BAD_CUSTOM_ENTITY_PARENT_DOMAIN"/>
+                    <enumeration value="BCC_NOT_ALLOWED_IF_BCC_COMPLIANCE_ENABLED"/>
+                    <enumeration value="CANNOT_CASCADE_PRODUCT_ACTIVE"/>
+                    <enumeration value="CANNOT_CHANGE_FIELD_TYPE_OF_APEX_REFERENCED_FIELD"/>
+                    <enumeration value="CANNOT_CHANGE_FIELD_TYPE_OF_REFERENCED_FIELD"/>
+                    <enumeration value="CANNOT_CREATE_ANOTHER_MANAGED_PACKAGE"/>
+                    <enumeration value="CANNOT_DEACTIVATE_DIVISION"/>
+                    <enumeration value="CANNOT_DELETE_GLOBAL_ACTION_LIST"/>
+                    <enumeration value="CANNOT_DELETE_LAST_DATED_CONVERSION_RATE"/>
+                    <enumeration value="CANNOT_DELETE_MANAGED_OBJECT"/>
+                    <enumeration value="CANNOT_DISABLE_LAST_ADMIN"/>
+                    <enumeration value="CANNOT_ENABLE_IP_RESTRICT_REQUESTS"/>
+                    <enumeration value="CANNOT_EXECUTE_FLOW_TRIGGER"/>
+                    <enumeration value="CANNOT_FREEZE_SELF"/>
+                    <enumeration value="CANNOT_INSERT_UPDATE_ACTIVATE_ENTITY"/>
+                    <enumeration value="CANNOT_MODIFY_MANAGED_OBJECT"/>
+                    <enumeration value="CANNOT_PASSWORD_LOCKOUT"/>
+                    <enumeration value="CANNOT_POST_TO_ARCHIVED_GROUP"/>
+                    <enumeration value="CANNOT_RENAME_APEX_REFERENCED_FIELD"/>
+                    <enumeration value="CANNOT_RENAME_APEX_REFERENCED_OBJECT"/>
+                    <enumeration value="CANNOT_RENAME_REFERENCED_FIELD"/>
+                    <enumeration value="CANNOT_RENAME_REFERENCED_OBJECT"/>
+                    <enumeration value="CANNOT_REPARENT_RECORD"/>
+                    <enumeration value="CANNOT_UPDATE_CONVERTED_LEAD"/>
+                    <enumeration value="CANT_DISABLE_CORP_CURRENCY"/>
+                    <enumeration value="CANT_UNSET_CORP_CURRENCY"/>
+                    <enumeration value="CHILD_SHARE_FAILS_PARENT"/>
+                    <enumeration value="CIRCULAR_DEPENDENCY"/>
+                    <enumeration value="CLEAN_SERVICE_ERROR"/>
+                    <enumeration value="COLLISION_DETECTED"/>
+                    <enumeration value="COMMUNITY_NOT_ACCESSIBLE"/>
+                    <enumeration value="CONFLICTING_ENVIRONMENT_HUB_MEMBER"/>
+                    <enumeration value="CONFLICTING_SSO_USER_MAPPING"/>
+                    <enumeration value="CUSTOM_APEX_ERROR"/>
+                    <enumeration value="CUSTOM_CLOB_FIELD_LIMIT_EXCEEDED"/>
+                    <enumeration value="CUSTOM_ENTITY_OR_FIELD_LIMIT"/>
+                    <enumeration value="CUSTOM_FIELD_INDEX_LIMIT_EXCEEDED"/>
+                    <enumeration value="CUSTOM_INDEX_EXISTS"/>
+                    <enumeration value="CUSTOM_LINK_LIMIT_EXCEEDED"/>
+                    <enumeration value="CUSTOM_METADATA_LIMIT_EXCEEDED"/>
+                    <enumeration value="CUSTOM_SETTINGS_LIMIT_EXCEEDED"/>
+                    <enumeration value="CUSTOM_TAB_LIMIT_EXCEEDED"/>
+                    <enumeration value="DATACLOUDADDRESS_NO_RECORDS_FOUND"/>
+                    <enumeration value="DATACLOUDADDRESS_PROCESSING_ERROR"/>
+                    <enumeration value="DATACLOUDADDRESS_SERVER_ERROR"/>
+                    <enumeration value="DELETE_FAILED"/>
+                    <enumeration value="DELETE_OPERATION_TOO_LARGE"/>
+                    <enumeration value="DELETE_REQUIRED_ON_CASCADE"/>
+                    <enumeration value="DEPENDENCY_EXISTS"/>
+                    <enumeration value="DUPLICATES_DETECTED"/>
+                    <enumeration value="DUPLICATE_CASE_SOLUTION"/>
+                    <enumeration value="DUPLICATE_COMM_NICKNAME"/>
+                    <enumeration value="DUPLICATE_CUSTOM_ENTITY_DEFINITION"/>
+                    <enumeration value="DUPLICATE_CUSTOM_TAB_MOTIF"/>
+                    <enumeration value="DUPLICATE_DEVELOPER_NAME"/>
+                    <enumeration value="DUPLICATE_EXTERNAL_ID"/>
+                    <enumeration value="DUPLICATE_MASTER_LABEL"/>
+                    <enumeration value="DUPLICATE_SENDER_DISPLAY_NAME"/>
+                    <enumeration value="DUPLICATE_USERNAME"/>
+                    <enumeration value="DUPLICATE_VALUE"/>
+                    <enumeration value="EMAIL_NOT_PROCESSED_DUE_TO_PRIOR_ERROR"/>
+                    <enumeration value="EMPTY_SCONTROL_FILE_NAME"/>
+                    <enumeration value="ENTITY_FAILED_IFLASTMODIFIED_ON_UPDATE"/>
+                    <enumeration value="ENTITY_IS_ARCHIVED"/>
+                    <enumeration value="ENTITY_IS_DELETED"/>
+                    <enumeration value="ENTITY_IS_LOCKED"/>
+                    <enumeration value="ENTITY_SAVE_ERROR"/>
+                    <enumeration value="ENTITY_SAVE_VALIDATION_ERROR"/>
+                    <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_CONFLICT"/>
+                    <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_ERROR_JOINING_HUB"/>
+                    <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_USER_ALREADY_IN_HUB"/>
+                    <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_USER_NOT_ORG_ADMIN"/>
+                    <enumeration value="ERROR_IN_MAILER"/>
+                    <enumeration value="FAILED_ACTIVATION"/>
+                    <enumeration value="FIELD_CUSTOM_VALIDATION_EXCEPTION"/>
+                    <enumeration value="FIELD_FILTER_VALIDATION_EXCEPTION"/>
+                    <enumeration value="FIELD_INTEGRITY_EXCEPTION"/>
+                    <enumeration value="FIELD_NOT_UPDATABLE"/>
+                    <enumeration value="FILTERED_LOOKUP_LIMIT_EXCEEDED"/>
+                    <enumeration value="FIND_DUPLICATES_ERROR"/>
+                    <enumeration value="HTML_FILE_UPLOAD_NOT_ALLOWED"/>
+                    <enumeration value="IMAGE_TOO_LARGE"/>
+                    <enumeration value="INACTIVE_OWNER_OR_USER"/>
+                    <enumeration value="INACTIVE_RULE_ERROR"/>
+                    <enumeration value="INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE"/>
+                    <enumeration value="INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY"/>
+                    <enumeration value="INSUFFICIENT_ACCESS_OR_READONLY"/>
+                    <enumeration value="INSUFFICIENT_CREDITS"/>
+                    <enumeration value="INVALID_ACCESS_LEVEL"/>
+                    <enumeration value="INVALID_ARGUMENT_TYPE"/>
+                    <enumeration value="INVALID_ASSIGNEE_TYPE"/>
+                    <enumeration value="INVALID_ASSIGNMENT_RULE"/>
+                    <enumeration value="INVALID_BATCH_OPERATION"/>
+                    <enumeration value="INVALID_CONTENT_TYPE"/>
+                    <enumeration value="INVALID_CREDIT_CARD_INFO"/>
+                    <enumeration value="INVALID_CROSS_REFERENCE_KEY"/>
+                    <enumeration value="INVALID_CROSS_REFERENCE_TYPE_FOR_FIELD"/>
+                    <enumeration value="INVALID_CURRENCY_CONV_RATE"/>
+                    <enumeration value="INVALID_CURRENCY_CORP_RATE"/>
+                    <enumeration value="INVALID_CURRENCY_ISO"/>
+                    <enumeration value="INVALID_DATA_CATEGORY_GROUP_REFERENCE"/>
+                    <enumeration value="INVALID_DATA_URI"/>
+                    <enumeration value="INVALID_EMAIL_ADDRESS"/>
+                    <enumeration value="INVALID_EMPTY_KEY_OWNER"/>
+                    <enumeration value="INVALID_ENTITY_FOR_MATCH_ENGINE_ERROR"/>
+                    <enumeration value="INVALID_ENTITY_FOR_MATCH_OPERATION_ERROR"/>
+                    <enumeration value="INVALID_ENVIRONMENT_HUB_MEMBER"/>
+                    <enumeration value="INVALID_EVENT_PUBLICATION"/>
+                    <enumeration value="INVALID_FIELD"/>
+                    <enumeration value="INVALID_FIELD_FOR_INSERT_UPDATE"/>
+                    <enumeration value="INVALID_FIELD_WHEN_USING_TEMPLATE"/>
+                    <enumeration value="INVALID_FILTER_ACTION"/>
+                    <enumeration value="INVALID_GOOGLE_DOCS_URL"/>
+                    <enumeration value="INVALID_ID_FIELD"/>
+                    <enumeration value="INVALID_INET_ADDRESS"/>
+                    <enumeration value="INVALID_INPUT"/>
+                    <enumeration value="INVALID_LINEITEM_CLONE_STATE"/>
+                    <enumeration value="INVALID_MASTER_OR_TRANSLATED_SOLUTION"/>
+                    <enumeration value="INVALID_MESSAGE_ID_REFERENCE"/>
+                    <enumeration value="INVALID_OAUTH_URL"/>
+                    <enumeration value="INVALID_OPERATION"/>
+                    <enumeration value="INVALID_OPERATOR"/>
+                    <enumeration value="INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST"/>
+                    <enumeration value="INVALID_OWNER"/>
+                    <enumeration value="INVALID_PACKAGE_LICENSE"/>
+                    <enumeration value="INVALID_PACKAGE_VERSION"/>
+                    <enumeration value="INVALID_PARTNER_NETWORK_STATUS"/>
+                    <enumeration value="INVALID_PERSON_ACCOUNT_OPERATION"/>
+                    <enumeration value="INVALID_QUERY_LOCATOR"/>
+                    <enumeration value="INVALID_READ_ONLY_USER_DML"/>
+                    <enumeration value="INVALID_RUNTIME_VALUE"/>
+                    <enumeration value="INVALID_SAVE_AS_ACTIVITY_FLAG"/>
+                    <enumeration value="INVALID_SESSION_ID"/>
+                    <enumeration value="INVALID_SETUP_OWNER"/>
+                    <enumeration value="INVALID_SIGNUP_COUNTRY"/>
+                    <enumeration value="INVALID_SITE_DELETE_EXCEPTION"/>
+                    <enumeration value="INVALID_SITE_FILE_IMPORTED_EXCEPTION"/>
+                    <enumeration value="INVALID_SITE_FILE_TYPE_EXCEPTION"/>
+                    <enumeration value="INVALID_STATUS"/>
+                    <enumeration value="INVALID_SUBDOMAIN"/>
+                    <enumeration value="INVALID_TYPE"/>
+                    <enumeration value="INVALID_TYPE_FOR_OPERATION"/>
+                    <enumeration value="INVALID_TYPE_ON_FIELD_IN_RECORD"/>
+                    <enumeration value="INVALID_USERID"/>
+                    <enumeration value="IP_RANGE_LIMIT_EXCEEDED"/>
+                    <enumeration value="JIGSAW_IMPORT_LIMIT_EXCEEDED"/>
+                    <enumeration value="LICENSE_LIMIT_EXCEEDED"/>
+                    <enumeration value="LIGHT_PORTAL_USER_EXCEPTION"/>
+                    <enumeration value="LIMIT_EXCEEDED"/>
+                    <enumeration value="MALFORMED_ID"/>
+                    <enumeration value="MANAGER_NOT_DEFINED"/>
+                    <enumeration value="MASSMAIL_RETRY_LIMIT_EXCEEDED"/>
+                    <enumeration value="MASS_MAIL_LIMIT_EXCEEDED"/>
+                    <enumeration value="MATCH_DEFINITION_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_INVALID_ENGINE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_INVALID_RULE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_MISSING_ENGINE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_MISSING_OBJECT_TYPE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_MISSING_OPTIONS_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_MISSING_RULE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_UNKNOWN_RULE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_UNSUPPORTED_VERSION_ERROR"/>
+                    <enumeration value="MATCH_RUNTIME_ERROR"/>
+                    <enumeration value="MATCH_SERVICE_ERROR"/>
+                    <enumeration value="MATCH_SERVICE_TIMED_OUT"/>
+                    <enumeration value="MATCH_SERVICE_UNAVAILABLE_ERROR"/>
+                    <enumeration value="MAXIMUM_CCEMAILS_EXCEEDED"/>
+                    <enumeration value="MAXIMUM_DASHBOARD_COMPONENTS_EXCEEDED"/>
+                    <enumeration value="MAXIMUM_HIERARCHY_LEVELS_REACHED"/>
+                    <enumeration value="MAXIMUM_SIZE_OF_ATTACHMENT"/>
+                    <enumeration value="MAXIMUM_SIZE_OF_DOCUMENT"/>
+                    <enumeration value="MAX_ACTIONS_PER_RULE_EXCEEDED"/>
+                    <enumeration value="MAX_ACTIVE_RULES_EXCEEDED"/>
+                    <enumeration value="MAX_APPROVAL_STEPS_EXCEEDED"/>
+                    <enumeration value="MAX_FORMULAS_PER_RULE_EXCEEDED"/>
+                    <enumeration value="MAX_RULES_EXCEEDED"/>
+                    <enumeration value="MAX_RULE_ENTRIES_EXCEEDED"/>
+                    <enumeration value="MAX_TASK_DESCRIPTION_EXCEEEDED"/>
+                    <enumeration value="MAX_TM_RULES_EXCEEDED"/>
+                    <enumeration value="MAX_TM_RULE_ITEMS_EXCEEDED"/>
+                    <enumeration value="MERGE_FAILED"/>
+                    <enumeration value="MISSING_ARGUMENT"/>
+                    <enumeration value="MISSING_RECORD"/>
+                    <enumeration value="MIXED_DML_OPERATION"/>
+                    <enumeration value="NONUNIQUE_SHIPPING_ADDRESS"/>
+                    <enumeration value="NO_APPLICABLE_PROCESS"/>
+                    <enumeration value="NO_ATTACHMENT_PERMISSION"/>
+                    <enumeration value="NO_INACTIVE_DIVISION_MEMBERS"/>
+                    <enumeration value="NO_MASS_MAIL_PERMISSION"/>
+                    <enumeration value="NO_SUCH_USER_EXISTS"/>
+                    <enumeration value="NUMBER_OUTSIDE_VALID_RANGE"/>
+                    <enumeration value="NUM_HISTORY_FIELDS_BY_SOBJECT_EXCEEDED"/>
+                    <enumeration value="OPTED_OUT_OF_MASS_MAIL"/>
+                    <enumeration value="OP_WITH_INVALID_USER_TYPE_EXCEPTION"/>
+                    <enumeration value="PACKAGE_LICENSE_REQUIRED"/>
+                    <enumeration value="PACKAGING_API_INSTALL_FAILED"/>
+                    <enumeration value="PACKAGING_API_UNINSTALL_FAILED"/>
+                    <enumeration value="PALI_INVALID_ACTION_ID"/>
+                    <enumeration value="PALI_INVALID_ACTION_NAME"/>
+                    <enumeration value="PALI_INVALID_ACTION_TYPE"/>
+                    <enumeration value="PAL_INVALID_ENTITY_ID"/>
+                    <enumeration value="PAL_INVALID_FLEXIPAGE_ID"/>
+                    <enumeration value="PAL_INVALID_LAYOUT_ID"/>
+                    <enumeration value="PAL_INVALID_PARAMETERS"/>
+                    <enumeration value="PA_API_EXCEPTION"/>
+                    <enumeration value="PA_AXIS_FAULT"/>
+                    <enumeration value="PA_INVALID_ID_EXCEPTION"/>
+                    <enumeration value="PA_NO_ACCESS_EXCEPTION"/>
+                    <enumeration value="PA_NO_DATA_FOUND_EXCEPTION"/>
+                    <enumeration value="PA_URI_SYNTAX_EXCEPTION"/>
+                    <enumeration value="PA_VISIBLE_ACTIONS_FILTER_ORDERING_EXCEPTION"/>
+                    <enumeration value="PORTAL_NO_ACCESS"/>
+                    <enumeration value="PORTAL_USER_ALREADY_EXISTS_FOR_CONTACT"/>
+                    <enumeration value="PRIVATE_CONTACT_ON_ASSET"/>
+                    <enumeration value="QUERY_TIMEOUT"/>
+                    <enumeration value="RECORD_IN_USE_BY_WORKFLOW"/>
+                    <enumeration value="REPUTATION_MINIMUM_NUMBER_NOT_REACHED"/>
+                    <enumeration value="REQUEST_RUNNING_TOO_LONG"/>
+                    <enumeration value="REQUIRED_FEATURE_MISSING"/>
+                    <enumeration value="REQUIRED_FIELD_MISSING"/>
+                    <enumeration value="SELF_REFERENCE_FROM_FLOW"/>
+                    <enumeration value="SELF_REFERENCE_FROM_TRIGGER"/>
+                    <enumeration value="SHARE_NEEDED_FOR_CHILD_OWNER"/>
+                    <enumeration value="SINGLE_EMAIL_LIMIT_EXCEEDED"/>
+                    <enumeration value="STANDARD_PRICE_NOT_DEFINED"/>
+                    <enumeration value="STORAGE_LIMIT_EXCEEDED"/>
+                    <enumeration value="STRING_TOO_LONG"/>
+                    <enumeration value="SUBDOMAIN_IN_USE"/>
+                    <enumeration value="TABSET_LIMIT_EXCEEDED"/>
+                    <enumeration value="TEMPLATE_NOT_ACTIVE"/>
+                    <enumeration value="TEMPLATE_NOT_FOUND"/>
+                    <enumeration value="TERRITORY_REALIGN_IN_PROGRESS"/>
+                    <enumeration value="TEXT_DATA_OUTSIDE_SUPPORTED_CHARSET"/>
+                    <enumeration value="TOO_MANY_APEX_REQUESTS"/>
+                    <enumeration value="TOO_MANY_ENUM_VALUE"/>
+                    <enumeration value="TOO_MANY_POSSIBLE_USERS_EXIST"/>
+                    <enumeration value="TRANSFER_REQUIRES_READ"/>
+                    <enumeration value="UNABLE_TO_LOCK_ROW"/>
+                    <enumeration value="UNAVAILABLE_RECORDTYPE_EXCEPTION"/>
+                    <enumeration value="UNDELETE_FAILED"/>
+                    <enumeration value="UNKNOWN_EXCEPTION"/>
+                    <enumeration value="UNSPECIFIED_EMAIL_ADDRESS"/>
+                    <enumeration value="UNSUPPORTED_APEX_TRIGGER_OPERATON"/>
+                    <enumeration value="UNVERIFIED_SENDER_ADDRESS"/>
+                    <enumeration value="USER_OWNS_PORTAL_ACCOUNT_EXCEPTION"/>
+                    <enumeration value="USER_WITH_APEX_SHARES_EXCEPTION"/>
+                    <enumeration value="VF_COMPILE_ERROR"/>
+                    <enumeration value="WEBLINK_SIZE_LIMIT_EXCEEDED"/>
+                    <enumeration value="WEBLINK_URL_INVALID"/>
+                    <enumeration value="WRONG_CONTROLLER_TYPE"/>
+                    <enumeration value="XCLEAN_UNEXPECTED_ERROR"/>
+                </restriction>
+            </simpleType>
+
+
+            <complexType name="Error">
+                <sequence>
+                    <element name="fields"     type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="message"    type="xsd:string"/>
+                    <element name="statusCode" type="tns:StatusCode"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="SendEmailError">
+                <sequence>
+                    <element name="fields"     type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="message"    type="xsd:string"/>
+                    <element name="statusCode" type="tns:StatusCode"/>
+                    <element name="targetObjectId"     type="tns:ID"  nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="SaveResult">
+                <sequence>
+                    <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="id"        type="tns:ID" nillable="true"/>
+                    <element name="success"   type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="UpsertResult">
+                <sequence>
+                    <element name="created"  type="xsd:boolean"/>
+                    <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="id"       type="tns:ID" nillable="true"/>
+                    <element name="success"   type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="PerformQuickActionResult">
+                <sequence>
+                    <element name="contextId" type="tns:ID" minOccurs="0" nillable="true"/>
+                    <element name="created"  type="xsd:boolean"/>
+                    <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="feedItemIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+                    <element name="ids"       type="tns:ID" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+                    <element name="success"   type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="QuickActionTemplateResult">
+                <sequence>
+                    <element name="defaultValueFormulas"  type="ens:sObject" nillable="true"/>
+                    <element name="defaultValues"         type="ens:sObject" nillable="true"/>
+                    <element name="errors"                type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="success"               type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="MergeRequest">
+                <sequence>
+                    <element name="masterRecord" type="ens:sObject"/>
+                    <element name="recordToMergeIds" type="tns:ID" minOccurs="1" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="MergeResult">
+                <sequence>
+                    <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="id"        type="tns:ID" nillable="true"/>
+                    <element name="mergedRecordIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="success"   type="xsd:boolean"/>
+                    <element name="updatedRelatedIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ProcessRequest">
+                <sequence>
+                    <element name="comments"       type="xsd:string" nillable="true"/>
+                    <element name="nextApproverIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ProcessSubmitRequest">
+                <complexContent>
+                    <extension base="tns:ProcessRequest">
+                        <sequence>
+                            <element name="objectId"     type="tns:ID"/>
+                            <element name="submitterId"    type="tns:ID" nillable="true"/>
+                            <element name="processDefinitionNameOrId" type="xsd:string" nillable="true"/>
+                            <element name="skipEntryCriteria" type="xsd:boolean" nillable="true"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ProcessWorkitemRequest">
+                <complexContent>
+                    <extension base="tns:ProcessRequest">
+                        <sequence>
+                            <element name="action"         type="xsd:string"/>
+                            <element name="workitemId"     type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+            <complexType name="PerformQuickActionRequest">
+                <sequence>
+                    <element name="contextId"      type="tns:ID" nillable="true"/>                    <element name="quickActionName"  type="xsd:string"/>
+                    <element name="records"       type="ens:sObject" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeAvailableQuickActionResult">
+                <sequence>
+                    <element name="label"        type="xsd:string"/>
+                    <element name="name"         type="xsd:string"/>
+                    <element name="type"         type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeQuickActionResult">
+                <sequence>
+                    <element name="accessLevelRequired"    type="tns:ShareAccessLevel" nillable="true"/> 
+                    <element name="canvasApplicationId"    type="tns:ID" nillable="true"/>                    
+                    <element name="canvasApplicationName"    type="xsd:string" nillable="true"/>
+                    <element name="colors" type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/> 
+                    <element name="contextSobjectType"    type="xsd:string" nillable="true"/> 
+                    <element name="defaultValues" type="tns:DescribeQuickActionDefaultValue" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="height"        type="xsd:int" nillable="true"/>
+                    <element name="iconName"      type="xsd:string" nillable="true"/>
+                    <element name="iconUrl"       type="xsd:string" nillable="true"/>
+                    <element name="icons"            type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="label"        type="xsd:string"/>
+                    <element name="layout"          type="tns:DescribeLayoutSection" nillable="true"/>
+                    <element name="miniIconUrl"      type="xsd:string" nillable="true"/>
+                    <element name="name"         type="xsd:string"/>
+                                        <element name="targetParentField"    type="xsd:string" nillable="true"/>
+                    <element name="targetRecordTypeId"   type="tns:ID" nillable="true"/>
+                    <element name="targetSobjectType"    type="xsd:string" nillable="true"/>
+                    <element name="type"         type="xsd:string"/>
+                    <element name="visualforcePageName"    type="xsd:string" nillable="true"/>
+                    <element name="width"         type="xsd:int" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeQuickActionDefaultValue">
+                <sequence>
+                    <element name="defaultValue"	type="xsd:string" nillable="true"/>
+                    <element name="field" 		type="xsd:string" nillable="false"/>
+                </sequence>
+            </complexType>
+
+
+
+            <simpleType name="ShareAccessLevel">
+                <restriction base="xsd:string">
+                    <enumeration value="Read"/>
+                    <enumeration value="Edit"/>
+                    <enumeration value="All"/>
+                </restriction>
+            </simpleType>
+
+
+
+
+            <complexType name="ProcessResult">
+                <sequence>
+                    <element name="actorIds"        type="tns:ID" nillable="false" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="entityId"        type="tns:ID" nillable="true"/>
+                    <element name="errors"          type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="instanceId"      type="tns:ID" nillable="true"/>
+                    <element name="instanceStatus"  type="xsd:string" nillable="true"/>
+                    <element name="newWorkitemIds"  type="tns:ID" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="success"         type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+
+
+
+
+            <complexType name="DeleteResult">
+                <sequence>
+                    <element name="errors"    type="tns:Error" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="id"        type="tns:ID" nillable="true"/>
+                    <element name="success"   type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="UndeleteResult">
+                <sequence>
+                    <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="id"        type="tns:ID" nillable="true"/>
+                    <element name="success"   type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="EmptyRecycleBinResult">
+                <sequence>
+                    <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="id"        type="tns:ID" nillable="true"/>
+                    <element name="success"   type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="LeadConvert">
+                <sequence>
+                    <element name="accountId"              type="tns:ID" nillable="true"/>
+                    <element name="contactId"              type="tns:ID" nillable="true"/>
+                    <element name="convertedStatus"        type="xsd:string"/>
+                    <element name="doNotCreateOpportunity" type="xsd:boolean"/>
+                    <element name="leadId"                 type="tns:ID"/>
+                    <element name="opportunityName"        type="xsd:string" nillable="true"/>
+                    <element name="overwriteLeadSource"    type="xsd:boolean"/>
+                    <element name="ownerId"                type="tns:ID"     nillable="true"/>
+                    <element name="sendNotificationEmail"  type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="LeadConvertResult">
+                <sequence>
+                    <element name="accountId"     type="tns:ID" nillable="true"/>
+                    <element name="contactId"     type="tns:ID" nillable="true"/>
+                    <element name="errors"        type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="leadId"        type="tns:ID" nillable="true"/>
+                    <element name="opportunityId" type="tns:ID" nillable="true"/>
+                    <element name="success"       type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSObjectResult">
+                <sequence>
+                    <element name="actionOverrides"	  type="tns:ActionOverride" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="activateable"        type="xsd:boolean"/>
+                    <element name="childRelationships"  type="tns:ChildRelationship" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="compactLayoutable"   type="xsd:boolean"/>
+                    <element name="createable"          type="xsd:boolean"/>
+                    <element name="custom"              type="xsd:boolean"/>
+                    <element name="customSetting"       type="xsd:boolean"/>
+                    <element name="deletable"           type="xsd:boolean"/>
+                    <element name="deprecatedAndHidden" type="xsd:boolean"/>
+                    <element name="feedEnabled"         type="xsd:boolean"/>
+                    <element name="fields"              type="tns:Field" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="keyPrefix"           type="xsd:string" nillable="true"/>
+                    <element name="label"               type="xsd:string"/>
+                    <element name="labelPlural"         type="xsd:string"/>
+                    <element name="layoutable"          type="xsd:boolean"/>
+                    <element name="mergeable"           type="xsd:boolean"/>
+                    <element name="name"                type="xsd:string"/>
+                    <element name="namedLayoutInfos"    type="tns:NamedLayoutInfo" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="queryable"           type="xsd:boolean"/>
+                    <element name="recordTypeInfos"     type="tns:RecordTypeInfo" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="replicateable"       type="xsd:boolean"/>
+                    <element name="retrieveable"        type="xsd:boolean"/>
+                    <element name="searchLayoutable"    type="xsd:boolean" minOccurs="0"/>
+                    <element name="searchable"          type="xsd:boolean" />
+                    <element name="triggerable"         type="xsd:boolean" minOccurs="0"/>
+                    <element name="undeletable"         type="xsd:boolean"/>
+                    <element name="updateable"          type="xsd:boolean"/>
+                    <element name="urlDetail"           type="xsd:string" nillable="true"/>
+                    <element name="urlEdit"             type="xsd:string" nillable="true"/>
+                    <element name="urlNew"              type="xsd:string" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <!-- this is a subset of properties for each SObject that is returned by the describeGlobal call -->
+            <complexType name="DescribeGlobalSObjectResult">
+                <sequence>
+                    <element name="activateable"        type="xsd:boolean"/>
+                    <element name="createable"          type="xsd:boolean"/>
+                    <element name="custom"              type="xsd:boolean"/>
+                    <element name="customSetting"       type="xsd:boolean"/>
+                    <element name="deletable"           type="xsd:boolean"/>
+                    <element name="deprecatedAndHidden" type="xsd:boolean"/>
+                    <element name="feedEnabled"         type="xsd:boolean"/>
+                    <element name="keyPrefix"           type="xsd:string" nillable="true"/>
+                    <element name="label"               type="xsd:string"/>
+                    <element name="labelPlural"         type="xsd:string"/>
+                    <element name="layoutable"          type="xsd:boolean"/>
+                    <element name="mergeable"           type="xsd:boolean"/>
+                    <element name="name"                type="xsd:string"/>
+                    <element name="queryable"           type="xsd:boolean"/>
+                    <element name="replicateable"       type="xsd:boolean"/>
+                    <element name="retrieveable"        type="xsd:boolean"/>
+                    <element name="searchable"          type="xsd:boolean"/>
+                    <element name="triggerable"         type="xsd:boolean"/>
+                    <element name="undeletable"         type="xsd:boolean"/>
+                    <element name="updateable"          type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ChildRelationship">
+                <sequence>
+                    <element name="cascadeDelete"    type="xsd:boolean"/>
+                    <element name="childSObject"     type="xsd:string"/>
+                    <element name="deprecatedAndHidden" type="xsd:boolean"/>
+                    <element name="field"            type="xsd:string"/>
+                    <element name="junctionIdListName"  type="xsd:string" minOccurs="0"/>
+                    <element name="junctionReferenceTo" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="relationshipName" type="xsd:string" minOccurs="0"/>
+                    <element name="restrictedDelete" type="xsd:boolean" minOccurs="0"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeGlobalResult">
+                <sequence>
+                    <element name="encoding"       type="xsd:string" nillable="true"/>
+                    <element name="maxBatchSize"   type="xsd:int"/>
+                    <element name="sobjects"       type="tns:DescribeGlobalSObjectResult" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeGlobalTheme">
+                <sequence>
+                    <element name="global"       type="tns:DescribeGlobalResult"/>
+                    <element name="theme"       type="tns:DescribeThemeResult"/>
+                </sequence>
+            </complexType>
+
+
+        <simpleType name="fieldType">
+                <restriction base="xsd:string">
+                    <enumeration value="string"/>
+                    <enumeration value="picklist"/>
+                    <enumeration value="multipicklist"/>
+                    <enumeration value="combobox"/>
+                    <enumeration value="reference"/>
+                    <enumeration value="base64"/>
+                    <enumeration value="boolean"/>
+                    <enumeration value="currency"/>
+                    <enumeration value="textarea"/>
+                    <enumeration value="int"/>
+                    <enumeration value="double"/>
+                    <enumeration value="percent"/>
+                    <enumeration value="phone"/>
+                    <enumeration value="id"/>
+                    <enumeration value="date"/>
+                    <enumeration value="datetime"/>
+                    <enumeration value="time"/>
+                    <enumeration value="url"/>
+                    <enumeration value="email"/>
+                    <enumeration value="encryptedstring"/>
+                    <enumeration value="datacategorygroupreference"/>
+                    <enumeration value="location"/>
+                    <enumeration value="address"/>
+                    <enumeration value="anyType"/> <!-- can be string, picklist, reference, boolean, currency, int, double, percent, id, date, datetime, url, email -->
+
+                    <enumeration value="complexvalue"/>
+
+                </restriction>
+            </simpleType>
+
+            <simpleType name="soapType">
+                <restriction base="xsd:string">
+                    <enumeration value="tns:ID"/>
+                    <enumeration value="xsd:base64Binary"/>
+                    <enumeration value="xsd:boolean"/>
+                    <enumeration value="xsd:double"/>
+                    <enumeration value="xsd:int"/>
+                    <enumeration value="xsd:string"/>
+                    <enumeration value="xsd:date"/>
+                    <enumeration value="xsd:dateTime"/>
+                    <enumeration value="xsd:time"/>
+                    <enumeration value="urn:location" />
+                    <enumeration value="urn:address" />
+                    <enumeration value="xsd:anyType"/> <!-- can be id, booolean, double, int, string, date, dateTime -->
+
+                    <enumeration value="urn:RelationshipReferenceTo" />
+
+                </restriction>
+            </simpleType>
+
+            <complexType name="FilteredLookupInfo">
+                        <sequence>
+                            <element name="controllingFields"             type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                            <element name="dependent"              type="xsd:boolean"/>
+                            <element name="optionalFilter"              type="xsd:boolean"/>
+
+                        </sequence>
+            </complexType>
+
+            <complexType name="Field">
+                <sequence>
+                    <element name="autoNumber"                 type="xsd:boolean"/>
+                    <element name="byteLength"                 type="xsd:int"/>
+                    <element name="calculated"                 type="xsd:boolean"/>
+                    <element name="calculatedFormula"          type="xsd:string" minOccurs="0"/>
+                    <element name="cascadeDelete"              type="xsd:boolean" minOccurs="0"/>
+                    <element name="caseSensitive"              type="xsd:boolean"/>
+                    <element name="controllerName"             type="xsd:string" minOccurs="0"/>
+                    <element name="createable"                 type="xsd:boolean"/>
+                    <element name="custom"                     type="xsd:boolean"/>
+                    <element name="defaultValueFormula"        type="xsd:string" minOccurs="0"/>
+                    <element name="defaultedOnCreate"          type="xsd:boolean"/>
+                    <element name="dependentPicklist"          type="xsd:boolean" minOccurs="0"/>
+                    <element name="deprecatedAndHidden"        type="xsd:boolean"/>
+                    <element name="digits"                     type="xsd:int"/>
+                    <element name="displayLocationInDecimal"   type="xsd:boolean" minOccurs="0"/>
+                    <element name="encrypted"                  type="xsd:boolean" minOccurs="0"/>
+                    <element name="externalId"                 type="xsd:boolean" minOccurs="0"/>
+                    <element name="extraTypeInfo"              type="xsd:string"  minOccurs="0"/>
+                    <element name="filterable"                 type="xsd:boolean"/>
+
+                    <element name="filteredLookupInfo"			   type="tns:FilteredLookupInfo" nillable="true" minOccurs="0" />
+
+                    <element name="groupable"                  type="xsd:boolean"/>
+                    <element name="highScaleNumber"			   type="xsd:boolean" minOccurs="0" />
+                    <element name="htmlFormatted"              type="xsd:boolean" minOccurs="0"/>
+                    <element name="idLookup"                   type="xsd:boolean"/>
+                    <element name="inlineHelpText"             type="xsd:string" minOccurs="0"/>
+                    <element name="label"                      type="xsd:string"/>
+                    <element name="length"                     type="xsd:int"/>
+                    <element name="mask"                       type="xsd:string"  minOccurs="0"/>
+                    <element name="maskType"                   type="xsd:string"  minOccurs="0"/>
+                    <element name="name"                       type="xsd:string"/>
+                    <element name="nameField"                  type="xsd:boolean"/>
+                    <element name="namePointing"               type="xsd:boolean" minOccurs="0"/>
+                    <element name="nillable"                   type="xsd:boolean"/>
+                    <element name="permissionable"             type="xsd:boolean"/>
+                    <element name="picklistValues"             type="tns:PicklistEntry" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="precision"                  type="xsd:int"/>
+                    <element name="queryByDistance"            type="xsd:boolean" />
+                    <element name="referenceTargetField"       type="xsd:string" minOccurs="0"/>
+                    <element name="referenceTo"                type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="relationshipName"           type="xsd:string" minOccurs="0"/>
+                    <element name="relationshipOrder"          type="xsd:int" minOccurs="0"/>
+                    <element name="restrictedDelete"           type="xsd:boolean" minOccurs="0"/>
+                    <element name="restrictedPicklist"         type="xsd:boolean"/>
+                    <element name="scale"                      type="xsd:int"/>
+                    <element name="soapType"                   type="tns:soapType"/>
+                    <element name="sortable"                   type="xsd:boolean" minOccurs="0"/>
+                    <element name="type"                       type="tns:fieldType"/>
+                    <element name="unique"                     type="xsd:boolean"/>
+                    <element name="updateable"                 type="xsd:boolean"/>
+                    <element name="writeRequiresMasterRead"    type="xsd:boolean" minOccurs="0"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="PicklistEntry">
+                <sequence>
+                    <element name="active"       type="xsd:boolean"/>
+                    <element name="defaultValue" type="xsd:boolean"/>
+                    <element name="label"        type="xsd:string" nillable="true"/>
+                    <element name="validFor"     type="xsd:base64Binary" minOccurs="0"/>
+                    <element name="value"        type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeDataCategoryGroupResult">
+                <sequence>
+                    <element name="categoryCount" type="xsd:int"/>
+                    <element name="description"   type="xsd:string"/>
+                    <element name="label"         type="xsd:string"/>
+                    <element name="name"          type="xsd:string"/>
+                    <element name="sobject"       type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeDataCategoryGroupStructureResult">
+                <sequence>
+                    <element name="description"   type="xsd:string"/>
+                    <element name="label"         type="xsd:string"/>
+                    <element name="name"          type="xsd:string"/>
+                    <element name="sobject"       type="xsd:string"/>
+                    <element name="topCategories" type="tns:DataCategory" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DataCategoryGroupSobjectTypePair">
+                <sequence>
+                    <element name="dataCategoryGroupName" type="xsd:string"/>
+                    <element name="sobject"               type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DataCategory">
+                <sequence>
+                    <element name="childCategories" type="tns:DataCategory" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="label"           type="xsd:string"/>
+                    <element name="name"            type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="KnowledgeSettings">
+                   <sequence>
+                       <element name="defaultLanguage"  type="xsd:string" minOccurs="0" />
+                       <element name="knowledgeEnabled" type="xsd:boolean"/>
+                       <element name="languages"        type="tns:KnowledgeLanguageItem" minOccurs="0" maxOccurs="unbounded"/>
+                   </sequence>
+            </complexType>
+
+            <complexType name="KnowledgeLanguageItem">
+                   <sequence>
+                       <element name="active" type="xsd:boolean"/>
+                       <element name="name" type="xsd:string" />
+                   </sequence>
+            </complexType>
+
+
+            <simpleType name="differenceType">
+                   <restriction base="xsd:string">
+                       <enumeration value="DIFFERENT"/>
+                       <enumeration value="NULL"/>
+                       <enumeration value="SAME"/>
+                       <enumeration value="SIMILAR"/>
+                   </restriction>
+            </simpleType>
+
+            <complexType name="FieldDiff">
+                   <sequence>
+                       <element name="difference" type="tns:differenceType" nillable="false" minOccurs="1" maxOccurs="1"/>
+                       <element name="name" type="xsd:string" />
+                   </sequence>
+            </complexType>
+
+            <complexType name="AdditionalInformationMap">
+                   <sequence>
+                       <element name="name" type="xsd:string" />
+                       <element name="value" type="xsd:string" />
+                   </sequence>
+            </complexType>
+
+            <complexType name="MatchRecord">
+                   <sequence>
+                       <element name="additionalInformation" minOccurs="0" maxOccurs="unbounded" type="tns:AdditionalInformationMap"/>
+                       <element name="fieldDiffs" minOccurs="0" maxOccurs="unbounded" type="tns:FieldDiff"/>
+                       <element name="matchConfidence" type="xsd:double"/>
+                       <element name="record" type="ens:sObject"/>
+                   </sequence>
+            </complexType>
+
+            <complexType name="MatchResult">
+                   <sequence>
+                       <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                       <element name="entityType" type="xsd:string" />
+                       <element name="matchEngine" type="xsd:string" />
+                       <element name="matchRecords" minOccurs="0" maxOccurs="unbounded" type="tns:MatchRecord"/>
+                       <element name="rule" type="xsd:string" />
+                       <element name="size" type="xsd:int"/>
+                       <element name="success"   type="xsd:boolean"/>
+                   </sequence>
+            </complexType>
+
+            <complexType name="DuplicateResult">
+                   <sequence>
+                       <element name="allowSave" type="xsd:boolean"/>
+                       <element name="duplicateRule" type="xsd:string"/>
+                       <element name="duplicateRuleEntityType" type="xsd:string"/>
+                       <element name="errorMessage" type="xsd:string"/>
+                       <element name="matchResults" minOccurs="0" maxOccurs="unbounded" type="tns:MatchResult"/>
+                   </sequence>
+            </complexType>
+
+            <complexType name="DuplicateError">
+                <complexContent>
+                    <extension base="tns:Error">
+                        <sequence>
+                          <element name="duplicateResult" type="tns:DuplicateResult"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+            <complexType name="DescribeNounResult">
+                <sequence>
+ 				    <element name="caseValues" minOccurs="0" maxOccurs="unbounded" type="tns:NameCaseValue"/>
+   		    	    <element name="developerName" type="xsd:string"/>
+                    <element name="gender" nillable="true" type="tns:Gender"/>
+   		    	    <element name="name" type="xsd:string"/>
+   		    	    <element name="pluralAlias" type="xsd:string" nillable="true"/>
+                    <element name="startsWith" nillable="true" type="tns:StartsWith"/>
+                </sequence>
+            </complexType>
+
+		   <complexType name="NameCaseValue">
+    			<sequence>
+				     <element name="article" nillable="true" type="tns:Article"/>
+				     <element name="caseType" nillable="true"  type="tns:CaseType"/>
+				     <element name="number" nillable="true" type="tns:GrammaticalNumber"/>
+				     <element name="possessive" nillable="true"  type="tns:Possessive"/>
+				     <element name="value" type="xsd:string"/>
+			    </sequence>
+		   </complexType>
+
+            <simpleType name="Article">
+                <restriction base="xsd:string">
+                    <enumeration value="None"/>
+                    <enumeration value="Indefinite"/>
+                    <enumeration value="Definite"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="CaseType">
+                <restriction base="xsd:string">
+                    <enumeration value="Nominative"/>
+                    <enumeration value="Accusative"/>
+                    <enumeration value="Genitive"/>
+                    <enumeration value="Dative"/>
+                    <enumeration value="Inessive"/>
+                    <enumeration value="Elative"/>
+                    <enumeration value="Illative"/>
+                    <enumeration value="Adessive"/>
+                    <enumeration value="Ablative"/>
+                    <enumeration value="Allative"/>
+                    <enumeration value="Essive"/>
+                    <enumeration value="Translative"/>
+                    <enumeration value="Partitive"/>
+                    <enumeration value="Objective"/>
+                    <enumeration value="Subjective"/>
+                    <enumeration value="Instrumental"/>
+                    <enumeration value="Prepositional"/>
+                    <enumeration value="Locative"/>
+                    <enumeration value="Vocative"/>
+                    <enumeration value="Sublative"/>
+                    <enumeration value="Superessive"/>
+                    <enumeration value="Delative"/>
+                    <enumeration value="Causalfinal"/>
+                    <enumeration value="Essiveformal"/>
+                    <enumeration value="Termanative"/>
+                    <enumeration value="Distributive"/>
+                    <enumeration value="Ergative"/>
+                    <enumeration value="Adverbial"/>
+                    <enumeration value="Abessive"/>
+                    <enumeration value="Comitative"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="Gender">
+                <restriction base="xsd:string">
+                    <enumeration value="Neuter"/>
+                    <enumeration value="Masculine"/>
+                    <enumeration value="Feminine"/>
+                    <enumeration value="AnimateMasculine"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="GrammaticalNumber">
+                <restriction base="xsd:string">
+                    <enumeration value="Singular"/>
+                    <enumeration value="Plural"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="Possessive">
+                <restriction base="xsd:string">
+                    <enumeration value="None"/>
+                    <enumeration value="First"/>
+                    <enumeration value="Second"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="StartsWith">
+                <restriction base="xsd:string">
+                    <enumeration value="Consonant"/>
+                    <enumeration value="Vowel"/>
+                    <enumeration value="Special"/>
+                </restriction>
+            </simpleType>
+
+
+
+
+
+            <complexType name="DescribeFlexiPageResult">
+                <sequence>
+                    <element name="id"      		type="tns:ID"/>
+                    <element name="label"            type="xsd:string"/>
+                    <element name="name"            type="xsd:string"/>
+                    <element name="quickActionList"             type="tns:DescribeQuickActionListResult" minOccurs="0" />
+                    <element name="regions"			type="tns:DescribeFlexiPageRegion" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="sobjectType"     type="xsd:string" minOccurs="0" nillable="true"/>
+                    <element name="template"     type="xsd:string" nillable="true"/>
+                    <element name="type"            type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeFlexiPageRegion">
+                <sequence>
+                    <element name="components"  	type="tns:DescribeComponentInstance" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="name"   			type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeComponentInstance">
+                <sequence>
+                    <element name="properties"  	type="tns:DescribeComponentInstanceProperty" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="typeName"   		type="xsd:string"/>
+                    <element name="typeNamespace"   type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeComponentInstanceProperty">
+                <sequence>
+                    <element name="name"   			type="xsd:string"/>
+                    <element name="region"          type="tns:DescribeFlexiPageRegion" nillable="true"/>
+                    <element name="value"   		type="xsd:string" nillable="true" />
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeAppMenuResult">
+                <sequence>
+                    <element name="appMenuItems"    type="tns:DescribeAppMenuItem" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeAppMenuItem">
+                <sequence>
+                    <element name="colors"           type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="content"         type="xsd:string"/>
+                    <element name="icons"           type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="label"           type="xsd:string"/>
+                    <element name="name"            type="xsd:string"/>
+                    <element name="type"            type="xsd:string"/>
+                    <element name="url"             type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+
+            <complexType name="DescribeThemeResult">
+                <sequence>
+                    <element name="themeItems"    type="tns:DescribeThemeItem" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeThemeItem">
+                <sequence>
+                    <element name="colors" type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="icons" type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="name"            type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoftphoneLayoutResult">
+                <sequence>
+                    <element name="callTypes" type="tns:DescribeSoftphoneLayoutCallType" maxOccurs="unbounded"/>
+                    <element name="id" type="tns:ID"/>
+                    <element name="name" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoftphoneLayoutCallType">
+                <sequence>
+                    <element name="infoFields" type="tns:DescribeSoftphoneLayoutInfoField" maxOccurs="unbounded"/>
+                    <element name="name" type="xsd:string"/>
+                    <element name="screenPopOptions" type="tns:DescribeSoftphoneScreenPopOption" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="screenPopsOpenWithin" type="xsd:string" minOccurs="0"/>
+                    <element name="sections" type="tns:DescribeSoftphoneLayoutSection" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoftphoneScreenPopOption">
+                <sequence>
+                    <element name="matchType" type="xsd:string"/>
+                    <element name="screenPopData" type="xsd:string"/>
+                    <element name="screenPopType" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoftphoneLayoutInfoField">
+                <sequence>
+                    <element name="name" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoftphoneLayoutSection">
+                <sequence>
+                    <element name="entityApiName" type="xsd:string"/>
+                    <element name="items" type="tns:DescribeSoftphoneLayoutItem" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoftphoneLayoutItem">
+                <sequence>
+                    <element name="itemApiName" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeCompactLayoutsResult">
+                <sequence>
+                    <element name="compactLayouts" type="tns:DescribeCompactLayout" maxOccurs="unbounded"/>
+                    <element name="defaultCompactLayoutId" type="tns:ID"/>
+                    <element name="recordTypeCompactLayoutMappings" type="tns:RecordTypeCompactLayoutMapping" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeCompactLayout">
+                <sequence>
+                    <element name="actions" type="tns:DescribeLayoutButton" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="fieldItems" type="tns:DescribeLayoutItem" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="id" type="tns:ID"/>
+                    <element name="imageItems" type="tns:DescribeLayoutItem" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="label" type="xsd:string"/>
+                    <element name="name" type="xsd:string"/>
+                    <element name="objectType" type="xsd:string"/> 
+                </sequence>
+            </complexType>
+
+            <complexType name="RecordTypeCompactLayoutMapping">
+                <sequence>
+                    <element name="available" type="xsd:boolean"/>
+                    <element name="compactLayoutId" type="tns:ID" nillable="true"/>
+                    <element name="compactLayoutName" type="xsd:string"/>
+                    <element name="recordTypeId" type="tns:ID"/>
+                    <element name="recordTypeName" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+
+            <complexType name="DescribeApprovalLayoutResult">
+                <sequence>
+                    <element name="approvalLayouts" type="tns:DescribeApprovalLayout" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeApprovalLayout">
+                <sequence>
+                    <element name="id" type="tns:ID"/>
+                    <element name="label" type="xsd:string"/>
+                    <element name="layoutItems" type="tns:DescribeLayoutItem" maxOccurs="unbounded"/>
+                    <element name="name" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeLayoutResult">
+                <sequence>
+                    <element name="layouts"            type="tns:DescribeLayout" maxOccurs="unbounded"/>
+                    <element name="recordTypeMappings" type="tns:RecordTypeMapping" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="recordTypeSelectorRequired" type="xsd:boolean" />
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeLayout">
+                <sequence>
+                    <element name="buttonLayoutSection"  type="tns:DescribeLayoutButtonSection" minOccurs="0"/>
+                    <element name="detailLayoutSections" type="tns:DescribeLayoutSection" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="editLayoutSections"   type="tns:DescribeLayoutSection" minOccurs="0" maxOccurs="unbounded"/>
+
+                    <element name="feedView"                    type="tns:DescribeLayoutFeedView" minOccurs="0" />
+
+
+                    <element name="highlightsPanelLayoutSection"  type="tns:DescribeLayoutSection" minOccurs="0" />
+
+                    <element name="id"                   type="tns:ID" nillable="true"/>
+
+
+
+                    <element name="quickActionList"             type="tns:DescribeQuickActionListResult" minOccurs="0" />
+
+
+                    <element name="relatedContent"                type="tns:RelatedContent" minOccurs="0" maxOccurs="1"/>
+
+                    <element name="relatedLists"                type="tns:RelatedList" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeQuickActionListResult">
+                <sequence>
+                    <element name="quickActionListItems"       type="tns:DescribeQuickActionListItemResult" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeQuickActionListItemResult">
+                <sequence>
+                    <element name="accessLevelRequired"    type="tns:ShareAccessLevel" nillable="true"/> 
+                    <element name="colors" type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/> 
+                    <element name="iconUrl"       type="xsd:string" nillable="true"/>
+                    <element name="icons" type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="label"        type="xsd:string"/>
+                    <element name="miniIconUrl"      type="xsd:string" />
+                    <element name="quickActionName"        type="xsd:string" />
+                    <element name="targetSobjectType"    type="xsd:string" nillable="true"/>
+                    <element name="type"         type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeLayoutFeedView">
+                <sequence>
+                    <element name="feedFilters" type="tns:DescribeLayoutFeedFilter" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="FeedLayoutFilterType">
+                <restriction base="xsd:string">
+                    <enumeration value="AllUpdates"/>
+                    <enumeration value="FeedItemType"/>
+                </restriction>
+            </simpleType>
+
+            <complexType name="DescribeLayoutFeedFilter">
+                <sequence>
+                    <element name="label" type="xsd:string"/>
+                    <element name="name"  type="xsd:string"/>
+                    <element name="type"  type="tns:FeedLayoutFilterType"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="TabOrderType">
+                 <restriction base="xsd:string">
+                    <enumeration value="LeftToRight"/>
+                    <enumeration value="TopToBottom"/>
+                 </restriction>
+            </simpleType>
+
+            <complexType name="DescribeLayoutSection">
+                <sequence>
+                    <element name="columns"                 type="xsd:int"/>
+                    <element name="heading"                 type="xsd:string" nillable="true"/>
+                    <element name="layoutRows"              type="tns:DescribeLayoutRow" maxOccurs="unbounded"/>
+                    <element name="rows"                    type="xsd:int"/>
+                    <element name="tabOrder"              	type="tns:TabOrderType"/>
+                    <element name="useCollapsibleSection"   type="xsd:boolean"/>
+                    <element name="useHeading"              type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeLayoutButtonSection">
+                <sequence>
+                    <element name="detailButtons"         type="tns:DescribeLayoutButton" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+            <complexType name="DescribeLayoutRow">
+                <sequence>
+                    <element name="layoutItems"      type="tns:DescribeLayoutItem" maxOccurs="unbounded"/>
+                    <element name="numItems"         type="xsd:int"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeLayoutItem">
+                <sequence>
+
+                    <element name="editableForNew"         type="xsd:boolean"/>
+                    <element name="editableForUpdate"      type="xsd:boolean"/>
+
+                    <element name="label"            type="xsd:string" nillable="true"/>
+                    <element name="layoutComponents" type="tns:DescribeLayoutComponent" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="placeholder"      type="xsd:boolean"/>
+                    <element name="required"         type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="WebLinkWindowType">
+                <restriction base="xsd:string">
+                    <enumeration value="newWindow"/>
+                    <enumeration value="sidebar"/>
+                    <enumeration value="noSidebar"/>
+                    <enumeration value="replace"/>
+                    <enumeration value="onClickJavaScript"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="WebLinkPosition">
+                <restriction base="xsd:string">
+                    <enumeration value="fullScreen"/>
+                    <enumeration value="none"/>
+                    <enumeration value="topLeft"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="WebLinkType">
+                <restriction base="xsd:string">
+                    <enumeration value="url"/>
+                    <enumeration value="sControl"/>
+                    <enumeration value="javascript"/>
+                    <enumeration value="page"/>
+                    <enumeration value="flow"/>
+                </restriction>
+            </simpleType>
+
+
+            <complexType name="DescribeLayoutButton">
+                <sequence>
+                 
+                    <element name="behavior"       type="tns:WebLinkWindowType" nillable="true" minOccurs="0"/>
+                    
+                    
+                    <element name="colors"            type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/>
+                    
+                 
+                    <element name="content"        type="xsd:string" nillable="true" minOccurs="0"/>
+                    <element name="contentSource"        type="tns:WebLinkType" nillable="true" minOccurs="0"/>
+                  
+                    <element name="custom"           type="xsd:boolean"/>
+                   
+                    <element name="encoding"        type="xsd:string" nillable="true" minOccurs="0"/>
+                    <element name="height"        type="xsd:int" nillable="true" minOccurs="0"/>
+                   
+                    
+                    <element name="icons"            type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
+                    
+                    <element name="label"            type="xsd:string" nillable="true"/>
+                    
+                    <element name="menubar"        type="xsd:boolean" nillable="true"/>
+                   
+                    <element name="name"             type="xsd:string" nillable="true"/>
+
+                    
+                    <element name="overridden"        type="xsd:boolean"/>
+                    <element name="resizeable"        type="xsd:boolean" nillable="true"/>
+                    <element name="scrollbars"        type="xsd:boolean" nillable="true"/>
+                    <element name="showsLocation"        type="xsd:boolean" nillable="true"/>
+                    <element name="showsStatus"        type="xsd:boolean" nillable="true"/>
+                    <element name="toolbar"        type="xsd:boolean" nillable="true"/>
+                    <element name="url"        type="xsd:string" nillable="true" minOccurs="0"/>
+                    <element name="width"        type="xsd:int" nillable="true" minOccurs="0"/>
+                    <element name="windowPosition"        type="tns:WebLinkPosition" nillable="true" minOccurs="0"/>
+                    
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeLayoutComponent">
+                <sequence>
+                    <element name="displayLines"      type="xsd:int"/>
+                    <element name="tabOrder"          type="xsd:int"/>
+                    <element name="type"              type="tns:layoutComponentType"/>
+                    <element name="value"             type="xsd:string" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="layoutComponentType">
+                <restriction base="xsd:string">
+                    <enumeration value="ReportChart"/>
+                    <enumeration value="Field"/>
+                    <enumeration value="Separator"/>
+                    <enumeration value="SControl"/>
+                    <enumeration value="EmptySpace"/>
+                    <enumeration value="VisualforcePage"/>
+
+                    <enumeration value="ExpandedLookup"/>
+
+
+                    <enumeration value="AuraComponent"/>
+
+
+                    <enumeration value="Canvas"/>
+                    <enumeration value="CustomLink"/>
+
+
+                    <enumeration value="AnalyticsCloud"/>
+
+                </restriction>
+            </simpleType>
+
+
+            <complexType name="FieldComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="field"              type="tns:Field"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+
+            <complexType name="FieldLayoutComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="components"             type="tns:DescribeLayoutComponent" minOccurs="0" maxOccurs="unbounded"/>
+                            <element name="fieldType"              type="tns:fieldType"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ReportChartComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="cacheData"              type="xsd:boolean"/>
+                            <element name="contextFilterableField" type="xsd:string"/>
+                            <element name="error"                  type="xsd:string"/>
+                            <element name="hideOnError"            type="xsd:boolean"/>
+                            <element name="includeContext"         type="xsd:boolean"/>
+                            <element name="showTitle"              type="xsd:boolean"/>
+                            <element name="size"                   type="tns:ReportChartSize"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="AnalyticsCloudComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="error"                  type="xsd:string"/>
+                            <element name="filter"                 type="xsd:string"/>
+                            <element name="height"                 type="xsd:string"/>
+                            <element name="hideOnError"            type="xsd:boolean"/>
+                            <element name="showTitle"              type="xsd:boolean"/>
+                            <element name="width"                  type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+            <complexType name="CustomLinkComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="customLink"             type="tns:DescribeLayoutButton"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+            <simpleType name="ReportChartSize">
+                <restriction base="xsd:string">
+                    <enumeration value="SMALL"/>
+                    <enumeration value="MEDIUM"/>
+                    <enumeration value="LARGE"/>
+                </restriction>
+            </simpleType>
+
+            <complexType name="NamedLayoutInfo">
+                <sequence>
+                    <element name="name" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="RecordTypeInfo">
+                <sequence>
+                    <element name="available"                 type="xsd:boolean"/>
+                    <element name="defaultRecordTypeMapping"  type="xsd:boolean"/>
+                    <element name="name"                      type="xsd:string"/>
+                    <element name="recordTypeId"              type="tns:ID" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="RecordTypeMapping">
+                <sequence>
+                    <element name="available"                 type="xsd:boolean"/>
+                    <element name="defaultRecordTypeMapping"  type="xsd:boolean"/>
+                    <element name="layoutId"                  type="tns:ID"/>
+                    <element name="name"                      type="xsd:string"/>
+                    <element name="picklistsForRecordType"    type="tns:PicklistForRecordType" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="recordTypeId"              type="tns:ID" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="PicklistForRecordType">
+                <sequence>
+                    <element name="picklistName"      type="xsd:string"/>
+                    <element name="picklistValues"    type="tns:PicklistEntry" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+
+             <complexType name="RelatedContent">
+                <sequence>
+                    <element name="relatedContentItems"         type="tns:DescribeRelatedContentItem" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeRelatedContentItem">
+                <sequence>
+                    <element name="describeLayoutItem"         type="tns:DescribeLayoutItem" maxOccurs="1"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="RelatedList">
+                <sequence>
+                    <element name="accessLevelRequiredForCreate"    type="tns:ShareAccessLevel" nillable="true"/> 
+ <element name="buttons"    type="tns:DescribeLayoutButton"  maxOccurs="unbounded" minOccurs="0" nillable="true"/> 
+                    <element name="columns"         type="tns:RelatedListColumn" maxOccurs="unbounded"/>
+                    <element name="custom"          type="xsd:boolean"/>
+                    <element name="field"           type="xsd:string" nillable="true"/>
+                    <element name="label"           type="xsd:string"/>
+                    <element name="limitRows"       type="xsd:int"/>
+                    <element name="name"            type="xsd:string"/>
+                    <element name="sobject"         type="xsd:string" nillable="true"/>
+                    <element name="sort"            type="tns:RelatedListSort" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="RelatedListColumn">
+                <sequence>
+                    <element name="field"           type="xsd:string" nillable="true"/>
+                    <element name="format"          type="xsd:string" nillable="true"/>
+                    <element name="label"           type="xsd:string"/>
+                    <element name="lookupId"        type="xsd:string"  nillable="true" minOccurs="0"/>
+                    <element name="name"            type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="RelatedListSort">
+                <sequence>
+                    <element name="ascending"       type="xsd:boolean"/>
+                    <element name="column"          type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+
+            <complexType name="EmailFileAttachment">
+                <sequence>
+                    <element name="body"                nillable="true" minOccurs="0" type="xsd:base64Binary"/>
+                    <element name="contentType"         nillable="true" minOccurs="0" type="xsd:string" />
+                    <element name="fileName"            type="xsd:string" />
+                    <element name="inline"				type="xsd:boolean" minOccurs="0"/>
+                </sequence>
+            </complexType>
+            <simpleType name="EmailPriority">
+                <restriction base="xsd:string">
+                    <enumeration value="Highest"/>
+                    <enumeration value="High"/>
+                    <enumeration value="Normal"/>
+                    <enumeration value="Low"/>
+                    <enumeration value="Lowest"/>
+                </restriction>
+            </simpleType>
+
+            <complexType name="Email">
+                <sequence>
+                    <element name="bccSender"         type="xsd:boolean" nillable="true"/>
+                    <element name="emailPriority"      type="tns:EmailPriority" nillable="true"/>
+                    <element name="replyTo"            type="xsd:string" nillable="true"/>
+                    <element name="saveAsActivity"     type="xsd:boolean" nillable="true"/>
+                    <element name="senderDisplayName"  type="xsd:string" nillable="true"/>
+                    <element name="subject"            type="xsd:string" nillable="true"/>
+                    <element name="useSignature"       type="xsd:boolean" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="MassEmailMessage">
+                <complexContent>
+                    <extension base="tns:Email">
+                        <sequence>
+                            <element name="description"  type="xsd:string" nillable="true"/>
+                            <element name="targetObjectIds"     minOccurs="0" maxOccurs="250" type="tns:ID" />
+                            <element name="templateId"          type="tns:ID"/>
+                            <element name="whatIds"             minOccurs="0" maxOccurs="250" type="tns:ID" />
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SingleEmailMessage">
+                <complexContent>
+                    <extension base="tns:Email">
+                        <sequence>
+                            <element name="bccAddresses"        minOccurs="0" maxOccurs="25" type="xsd:string" nillable="true"/>
+                            <element name="ccAddresses"         minOccurs="0" maxOccurs="25" type="xsd:string" nillable="true"/>
+                            <element name="charset"             type="xsd:string" nillable="true"/>
+                            <element name="documentAttachments" minOccurs="0" maxOccurs="unbounded" type="tns:ID" />
+                            <element name="htmlBody"       type="xsd:string" nillable="true"/>
+                            <element name="inReplyTo"           minOccurs="0" type="xsd:string" nillable="true"/>
+                            <element name="fileAttachments"     minOccurs="0" maxOccurs="unbounded" type="tns:EmailFileAttachment"/>
+                            <element name="orgWideEmailAddressId" minOccurs="0" maxOccurs="1" type="tns:ID" nillable="true"/>
+                            <element name="plainTextBody"       type="xsd:string" nillable="true"/>
+                            <element name="references"          minOccurs="0" type="xsd:string" nillable="true"/>
+                            <element name="targetObjectId"      type="tns:ID" nillable="true"/>
+                            <element name="templateId"          type="tns:ID" nillable="true"/>
+                            <element name="toAddresses"         minOccurs="0" maxOccurs="100" type="xsd:string" nillable="true"/>
+                            <element name="whatId"              type="tns:ID" nillable="true"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SendEmailResult">
+                <sequence>
+                    <element name="errors"              minOccurs="0" maxOccurs="unbounded" type="tns:SendEmailError" />
+                    <element name="success"             type="xsd:boolean" />
+                </sequence>
+            </complexType>
+
+
+
+            <complexType name="ListViewColumn">
+                <sequence>
+                    <element name="ascendingLabel"           type="xsd:string" nillable="true"/>
+                    <element name="descendingLabel"          type="xsd:string" nillable="true"/>
+                    <element name="fieldNameOrPath"          type="xsd:string"/>
+                    <element name="hidden"                   type="xsd:boolean"/>
+                    <element name="label"                    type="xsd:string"/>
+                    <element name="selectListItem"           type="xsd:string"/>
+                    <element name="sortDirection"            type="tns:orderByDirection" nillable="true"/>
+                    <element name="sortIndex"                type="xsd:int" nillable="true"/>
+                    <element name="sortable"                 type="xsd:boolean"/>
+                    <element name="type"                     type="tns:fieldType"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ListViewOrderBy">
+                <sequence>
+                    <element name="fieldNameOrPath"          type="xsd:string"/>
+                    <element name="nullsPosition"            type="tns:orderByNullsPosition" nillable="true"/>
+                    <element name="sortDirection"            type="tns:orderByDirection" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoqlListView">
+                <sequence>
+                    <element name="columns"                  type="tns:ListViewColumn" maxOccurs="unbounded"/>
+                    <element name="id"                       type="tns:ID"/>
+                    <element name="orderBy"                  type="tns:ListViewOrderBy" maxOccurs="unbounded"/>
+                    <element name="query"                    type="xsd:string"/>
+                    <element name="scope"                    type="xsd:string" nillable="true"/>
+                    <element name="sobjectType"              type="xsd:string"/>
+                    <element name="whereCondition"           type="tns:SoqlWhereCondition" minOccurs="0"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoqlListViewsRequest">
+                <sequence>
+                    <element name="listViewParams"      type="tns:DescribeSoqlListViewParams" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoqlListViewParams">
+                <sequence>
+                    <element name="developerNameOrId"        type="xsd:string"/>
+                    <element name="sobjectType"              type="xsd:string" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoqlListViewResult">
+                <sequence>
+                    <element name="describeSoqlListViews"    type="tns:DescribeSoqlListView" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ExecuteListViewRequest">
+                <sequence>
+                    <element name="developerNameOrId"        type="xsd:string"/>
+                    <element name="limit"                    type="xsd:int" nillable="true"/>
+                    <element name="offset"                   type="xsd:int" nillable="true"/>
+                    <element name="orderBy"                  type="tns:ListViewOrderBy" maxOccurs="unbounded"/>
+                    <element name="sobjectType"              type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ExecuteListViewResult">
+                <sequence>
+                    <element name="columns"                  type="tns:ListViewColumn" maxOccurs="unbounded"/>
+                    <element name="developerName"            type="xsd:string"/>
+                    <element name="done"                     type="xsd:boolean"/>
+                    <element name="id"                       type="tns:ID"/>
+                    <element name="label"                    type="xsd:string"/>
+                    <element name="records"                  type="tns:ListViewRecord" maxOccurs="unbounded"/>
+                    <element name="size"                     type="xsd:int"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ListViewRecord">
+                <sequence>
+                    <element name="columns"                  type="tns:ListViewRecordColumn" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ListViewRecordColumn">
+                <sequence>
+                    <element name="fieldNameOrPath"          type="xsd:string"/>
+                    <element name="value"                    type="xsd:string" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="orderByDirection">
+                <restriction base="xsd:string">
+                    <enumeration value="ascending"/>
+                    <enumeration value="descending"/>
+                </restriction>
+            </simpleType>
+
+            <simpleType name="orderByNullsPosition">
+                <restriction base="xsd:string">
+                    <enumeration value="first"/>
+                    <enumeration value="last"/>
+                </restriction>
+            </simpleType>
+
+            <simpleType name="soqlOperator">
+                <restriction base="xsd:string">
+                    <enumeration value="equals"/>
+                    <enumeration value="excludes"/>
+                    <enumeration value="greaterThan"/>
+                    <enumeration value="greaterThanOrEqualTo"/>
+                    <enumeration value="in"/>
+                    <enumeration value="includes"/>
+                    <enumeration value="lessThan"/>
+                    <enumeration value="lessThanOrEqualTo"/>
+                    <enumeration value="like"/>
+                    <enumeration value="notEquals"/>
+                    <enumeration value="notIn"/>
+                    <enumeration value="within"/>
+                </restriction>
+            </simpleType>
+
+            <simpleType name="soqlConjunction">
+                <restriction base="xsd:string">
+                    <enumeration value="and"/>
+                    <enumeration value="or"/>
+                </restriction>
+            </simpleType>
+
+            <complexType name="SoqlWhereCondition">
+                <sequence/>
+            </complexType>
+
+            <complexType name="SoqlCondition">
+                <complexContent>
+                    <extension base="tns:SoqlWhereCondition">
+                        <sequence>
+                            <element name="field"                    type="xsd:string"/>
+                            <element name="operator"                 type="tns:soqlOperator"/>
+                            <element name="values"                   type="xsd:string" maxOccurs="unbounded"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SoqlNotCondition">
+                <complexContent>
+                    <extension base="tns:SoqlWhereCondition">
+                        <sequence>
+                            <element name="condition"                type="tns:SoqlWhereCondition"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SoqlConditionGroup">
+                <complexContent>
+                    <extension base="tns:SoqlWhereCondition">
+                        <sequence>
+                            <element name="conditions"               type="tns:SoqlWhereCondition" maxOccurs="unbounded"/>
+                            <element name="conjunction"              type="tns:soqlConjunction"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SoqlSubQueryCondition">
+                <complexContent>
+                    <extension base="tns:SoqlWhereCondition">
+                        <sequence>
+                            <element name="field"                    type="xsd:string"/>
+                            <element name="operator"                 type="tns:soqlOperator"/>
+                            <element name="subQuery"                 type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+        
+            <complexType name="DescribeSearchLayoutResult">
+                <sequence>
+                    
+                    <element name="errorMsg" type="xsd:string" nillable="true"/>
+                    <element name="label" type="xsd:string" nillable="true"/>
+                    <element name="limitRows" type="xsd:int" nillable="true"/>
+                    <element name="objectType" type="xsd:string"/>
+                    <element name="searchColumns" type="tns:DescribeColumn" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+                </sequence>
+            </complexType>
+        
+
+                <complexType name="DescribeColumn">
+                    <sequence>
+                        <element name="field" type="xsd:string" />
+                        <element name="format" type="xsd:string" nillable="true"/>
+                        <element name="label" type="xsd:string" />
+                        <element name="name" type="xsd:string" />
+                    </sequence>
+                </complexType>
+
+
+
+
+            <complexType name="DescribeSearchScopeOrderResult">
+                <sequence>
+                    <element name="keyPrefix"       type="xsd:string" />
+                    <element name="name"            type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeTabSetResult">
+                <sequence>
+                    <element name="label"           type="xsd:string" />
+                    <element name="logoUrl"         type="xsd:string" />
+                    <element name="namespace"       type="xsd:string" minOccurs="0"/>
+                    <element name="selected"        type="xsd:boolean" />
+                    <element name="tabSetId" type="xsd:string" />
+                    <element name="tabs"            type="tns:DescribeTab" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeTab">
+                <sequence>
+                    <element name="colors" type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="custom"           type="xsd:boolean" />
+                    <element name="iconUrl"          type="xsd:string" />
+                    <element name="icons" type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="label"            type="xsd:string" />
+                    <element name="miniIconUrl"      type="xsd:string" />
+                    <element name="name" type="xsd:string" />
+                    <element name="sobjectName"      type="xsd:string" nillable="true" />
+                    <element name="url"              type="xsd:string" />
+                </sequence>
+            </complexType>
+
+
+        <complexType name="DescribeColor">
+            <sequence>
+                <element name="color"            type="xsd:string" />
+                <element name="context"          type="xsd:string" />
+                <element name="theme"            type="xsd:string" />
+            </sequence>
+        </complexType>
+
+
+
+        <complexType name="DescribeIcon">
+            <sequence>
+                <element name="contentType"     type="xsd:string" />
+                <element name="height"          type="xsd:int" nillable="true"/>
+                <element name="theme"           type="xsd:string" />
+                <element name="url"             type="xsd:string" />
+                <element name="width"           type="xsd:int" nillable="true" />
+            </sequence>
+        </complexType>
+
+        <complexType name="ActionOverride">
+            <sequence>
+                <element name="isAvailableInTouch" type="xsd:boolean"/>
+                <element name="name" type="xsd:string"/>
+                <element name="pageId" type="tns:ID"/>
+                <element name="url" type="xsd:string"/>
+            </sequence>
+        </complexType>
+
+
+
+
+            <!-- Login Message Types -->
+            <element name="login">
+                <complexType>
+                    <sequence>
+                        <element name="username" type="xsd:string"/>
+                        <element name="password" type="xsd:string"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="loginResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:LoginResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Describe Message Types -->
+            <element name="describeSObject">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeSObjectResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSObjectResult" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- DescibeSObjects Message Types -->
+            <element name="describeSObjects">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string" minOccurs='0' maxOccurs='100' />
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeSObjectsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSObjectResult" nillable="true" minOccurs='0' maxOccurs='100'/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Describe Global Message Types -->
+            <element name="describeGlobal">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="describeGlobalResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeGlobalResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+        <!-- Describe Global Theme Types -->
+        <element name="describeGlobalTheme">
+            <complexType>
+                <sequence/>
+            </complexType>
+        </element>
+        <element name="describeGlobalThemeResponse">
+            <complexType>
+                <sequence>
+                    <element name="result" type="tns:DescribeGlobalTheme"/>
+                </sequence>
+            </complexType>
+        </element>
+
+        <!-- Describe Theme Types -->
+        <element name="describeTheme">
+            <complexType>
+                <sequence>
+                    <element name="sobjectType" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+        </element>
+        <element name="describeThemeResponse">
+            <complexType>
+                <sequence>
+                    <element name="result" type="tns:DescribeThemeResult"/>
+                </sequence>
+            </complexType>
+        </element>
+
+
+        <!-- Describe Data Category Groups Message Types -->
+            <element name="describeDataCategoryGroups">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string" minOccurs='0' maxOccurs='10' />
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeDataCategoryGroupsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeDataCategoryGroupResult" minOccurs='0' maxOccurs='100'/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeDataCategoryGroupStructures">
+                <complexType>
+                    <sequence>
+                        <element name="pairs" type="tns:DataCategoryGroupSobjectTypePair" minOccurs='0' maxOccurs='100' />
+                        <element name="topCategoriesOnly" type="xsd:boolean"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeDataCategoryGroupStructuresResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeDataCategoryGroupStructureResult" minOccurs='0' maxOccurs='100'/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <!-- Describe Knowledge Settings -->
+            <element name="describeKnowledgeSettings">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="describeKnowledgeSettingsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:KnowledgeSettings"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+
+
+
+
+            <element name="describeFlexiPages">
+                <complexType>
+                    <sequence>
+                        <element name="flexiPages" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeFlexiPagesResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeFlexiPageResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <simpleType name="AppMenuType">
+                <restriction base="xsd:string">
+                    <enumeration value="AppSwitcher"/>
+                    <enumeration value="Salesforce1"/>
+                    <enumeration value="NetworkTabs"/>
+                </restriction>
+            </simpleType>
+
+
+            <element name="describeAppMenu">
+                <complexType>
+                    <sequence>
+                        <element name="appMenuType" type="tns:AppMenuType" />
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeAppMenuResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeAppMenuResult" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <element name="describeLayout">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="layoutName" type="xsd:string" nillable="true"/>
+                        <element name="recordTypeIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeLayoutResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeLayoutResult" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describeCompactLayouts">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="recordTypeIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeCompactLayoutsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeCompactLayoutsResult" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describePrimaryCompactLayouts">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectTypes" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describePrimaryCompactLayoutsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeCompactLayout" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describeApprovalLayout">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="approvalProcessNames" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeApprovalLayoutResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeApprovalLayoutResult" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="describeSoftphoneLayout">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="describeSoftphoneLayoutResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSoftphoneLayoutResult" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <element name="describeSoqlListViews">
+                <complexType>
+                    <sequence>
+                        <element name="request" type="tns:DescribeSoqlListViewsRequest"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeSoqlListViewsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSoqlListViewResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="executeListView">
+                <complexType>
+                    <sequence>
+                        <element name="request" type="tns:ExecuteListViewRequest"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="executeListViewResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:ExecuteListViewResult" minOccurs="0" maxOccurs="1"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <simpleType name="listViewIsSoqlCompatible">
+                <restriction base="xsd:string">
+                    <enumeration value="TRUE"/>
+                    <enumeration value="FALSE"/>
+                    <enumeration value="ALL"/>
+                </restriction>
+            </simpleType>
+
+            <element name="describeSObjectListViews">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="recentsOnly" type="xsd:boolean"/>
+                        <element name="isSoqlCompatible" type="tns:listViewIsSoqlCompatible"/>
+                        <element name="limit" type="xsd:int"/>
+                        <element name="offset" type="xsd:int"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeSObjectListViewsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSoqlListViewResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describeSearchLayouts">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeSearchLayoutsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSearchLayoutResult" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <element name="describeSearchScopeOrder">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="describeSearchScopeOrderResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSearchScopeOrderResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describeTabs">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="describeTabsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeTabSetResult" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describeAllTabs">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="describeAllTabsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeTab" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describeNouns">
+                <complexType>
+                    <sequence>
+                        <element name="nouns" type="xsd:string" minOccurs='0' maxOccurs='100' />
+                        <element name="onlyRenamed" type="xsd:boolean"/>
+                        <element name="includeFields" type="xsd:boolean"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeNounsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeNounResult" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <!-- Create Message Types -->
+            <element name="create">
+                <complexType>
+                    <sequence>
+                        <element name="sObjects" type="ens:sObject" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="createResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:SaveResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <!-- Send Email Types -->
+            <element name="sendEmail">
+                <complexType>
+                    <sequence>
+                        <element name="messages" type="tns:Email" minOccurs="0" maxOccurs="10"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="sendEmailResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" minOccurs="0" maxOccurs="10" type="tns:SendEmailResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Send Email Message Types -->
+            <element name="sendEmailMessage">
+                <complexType>
+                    <sequence>
+                        <element name="ids" type="tns:ID" minOccurs="0" maxOccurs="10"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="sendEmailMessageResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" minOccurs="0" maxOccurs="10" type="tns:SendEmailResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <!-- Update Message Types -->
+            <element name="update">
+                <complexType>
+                    <sequence>
+                        <element name="sObjects" type="ens:sObject" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="updateResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:SaveResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Upsert Message Types -->
+            <element name="upsert">
+                <complexType>
+                    <sequence>
+                        <element name="externalIDFieldName" type="xsd:string"/>
+                        <element name="sObjects" type="ens:sObject" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="upsertResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:UpsertResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Merge Message Types -->
+            <element name="merge">
+                <complexType>
+                    <sequence>
+                        <element name="request" type="tns:MergeRequest" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="mergeResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:MergeResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Delete Message Types -->
+            <element name="delete">
+                <complexType>
+                    <sequence>
+                        <element name="ids" type="tns:ID" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="deleteResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DeleteResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Undelete Message Types -->
+            <element name="undelete">
+                <complexType>
+                    <sequence>
+                        <element name="ids" type="tns:ID" minOccurs="1" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="undeleteResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:UndeleteResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- EmptyRecycleBin Message Types -->
+            <element name="emptyRecycleBin">
+                <complexType>
+                    <sequence>
+                        <element name="ids" type="tns:ID" minOccurs="1" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="emptyRecycleBinResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:EmptyRecycleBinResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Process Message Types -->
+            <element name="process">
+                <complexType>
+                    <sequence>
+                        <element name="actions" type="tns:ProcessRequest" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="processResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:ProcessResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <!-- Perform Action Message Types -->
+            <element name="performQuickActions">
+                <complexType>
+                    <sequence>
+                        <element name="quickActions" type="tns:PerformQuickActionRequest" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="performQuickActionsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:PerformQuickActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="retrieveQuickActionTemplates">
+                <complexType>
+                    <sequence>
+                        <element name="quickActionNames" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                        <element name="contextId" type="tns:ID" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="retrieveQuickActionTemplatesResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:QuickActionTemplateResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="describeQuickActions">
+                <complexType>
+                    <sequence>
+                        <element name="quickActions"       type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeQuickActionsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeQuickActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="describeAvailableQuickActions">
+                <complexType>
+                    <sequence>
+                        <element name="contextType"       type="xsd:string" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeAvailableQuickActionsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeAvailableQuickActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <!-- Retrieve (ID List) Message Types -->
+            <element name="retrieve">
+                <complexType>
+                    <sequence>
+                        <element name="fieldList"   type="xsd:string"/>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="ids"         type="tns:ID" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="retrieveResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="ens:sObject" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Convert Lead Message Types -->
+            <element name="convertLead">
+                <complexType>
+                    <sequence>
+                        <element name="leadConverts" type="tns:LeadConvert" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="convertLeadResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:LeadConvertResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Get Updated Message Types -->
+            <element name="getUpdated">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="startDate" type="xsd:dateTime"/>
+                        <element name="endDate" type="xsd:dateTime"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="getUpdatedResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:GetUpdatedResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Get Deleted Message Types -->
+            <element name="getDeleted">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="startDate" type="xsd:dateTime"/>
+                        <element name="endDate" type="xsd:dateTime"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="getDeletedResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:GetDeletedResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <!-- Logout current session -->
+            <element name="logout">
+                <complexType>
+                </complexType>
+            </element>
+
+            <element name="logoutResponse">
+                <complexType>
+                </complexType>
+            </element>
+
+            <!-- Invalidate a list of session ids -->
+            <element name="invalidateSessions">
+                <complexType>
+                    <sequence>
+                        <element name="sessionIds" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="invalidateSessionsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:InvalidateSessionsResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Create Query -->
+            <element name="query">
+                <complexType>
+                    <sequence>
+                        <element name="queryString" type="xsd:string"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="queryResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:QueryResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Create Query All -->
+            <element name="queryAll">
+                <complexType>
+                    <sequence>
+                        <element name="queryString" type="xsd:string"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="queryAllResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:QueryResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <!-- Next Batch of sObjects from a query -->
+            <element name="queryMore">
+                <complexType>
+                    <sequence>
+                        <element name="queryLocator" type="tns:QueryLocator"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="queryMoreResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:QueryResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <!-- Create Search -->
+            <element name="search">
+                <complexType>
+                    <sequence>
+                        <element name="searchString" type="xsd:string"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="searchResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:SearchResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <element name="getServerTimestamp">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="getServerTimestampResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:GetServerTimestampResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="setPassword">
+                <complexType>
+                    <sequence>
+                        <element name="userId" type="tns:ID"/>
+                        <element name="password" type="xsd:string"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="setPasswordResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:SetPasswordResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="resetPassword">
+                <complexType>
+                    <sequence>
+                        <element name="userId" type="tns:ID"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="resetPasswordResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:ResetPasswordResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="getUserInfo">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="getUserInfoResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:GetUserInfoResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <!-- Header Elements -->
+            <element name="SessionHeader">
+                <complexType>
+                    <sequence>
+                        <element name="sessionId" type="xsd:string"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="LoginScopeHeader">
+                <complexType>
+                    <sequence>
+                        <element name="organizationId" type="tns:ID"/>
+                        <element name="portalId" type="tns:ID" minOccurs="0"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="CallOptions">
+                <complexType>
+                    <sequence>
+                        <element name="client"            type="xsd:string" nillable="true"/>
+                        <element name="defaultNamespace"  type="xsd:string" nillable="true"/>
+
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="QueryOptions">
+                <complexType>
+                    <sequence>
+                        <element name="batchSize"       type="xsd:int" minOccurs="0"/>
+
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <simpleType name="DebugLevel">
+                <restriction base="xsd:string">
+                    <enumeration value="None"/>
+                    <enumeration value="DebugOnly"/>
+                    <enumeration value="Db"/>
+                </restriction>
+            </simpleType>
+            <element name="DebuggingHeader">
+                <complexType>
+                    <sequence>
+                        <element name="debugLevel" type="tns:DebugLevel"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="DebuggingInfo">
+                <complexType>
+                    <sequence>
+                        <element name="debugLog" type="xsd:string"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+   <xsd:complexType name="PackageVersion">
+    <xsd:sequence>
+     <xsd:element name="majorNumber" type="xsd:int"/>
+     <xsd:element name="minorNumber" type="xsd:int"/>
+     <xsd:element name="namespace" type="xsd:string"/>
+    </xsd:sequence>
+   </xsd:complexType>
+   <xsd:element name="PackageVersionHeader">
+    <xsd:complexType>
+     <xsd:sequence>
+      <xsd:element name="packageVersions" minOccurs="0" maxOccurs="unbounded" type="tns:PackageVersion"/>
+     </xsd:sequence>
+    </xsd:complexType>
+   </xsd:element>
+
+            <element name="AllowFieldTruncationHeader">
+                <complexType>
+                    <sequence>
+                        <element name="allowFieldTruncation" type="xsd:boolean" />
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="DisableFeedTrackingHeader">
+                <complexType>
+                    <sequence>
+                        <element name="disableFeedTracking" type="xsd:boolean" />
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <element name="StreamingEnabledHeader">
+                <complexType>
+                    <sequence>
+                        <element name="streamingEnabled" type="xsd:boolean" />
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+        <element name="AllOrNoneHeader">
+            <complexType>
+                <sequence>
+                    <element name="allOrNone" type="xsd:boolean" />
+                </sequence>
+            </complexType>
+        </element>
+
+
+
+        <element name="DuplicateRuleHeader">
+            <complexType>
+                <sequence>
+                    <element name="allowSave" type="xsd:boolean" />
+                    <element name="includeRecordDetails" type="xsd:boolean" />
+                    <element name="runAsCurrentUser" type="xsd:boolean" />
+                </sequence>
+            </complexType>
+        </element>
+
+
+
+        <complexType name="LimitInfo">
+            <sequence>
+                <element name="current" type="xsd:int"/>
+                <element name="limit" type="xsd:int"/>
+                <element name="type" type="xsd:string"/>
+            </sequence>
+        </complexType>
+
+        <element name="LimitInfoHeader">
+            <complexType>
+                <sequence>
+                    <element name="limitInfo" minOccurs="0" maxOccurs="unbounded" type="tns:LimitInfo"/>
+                </sequence>
+            </complexType>
+        </element>
+
+
+
+
+
+
+
+            <!-- ideally this could of just been elem name="..." type="xsd:boolean"
+                 but is required to be nested within a complexType for .NET 1.1 compatibility -->
+    <element name="MruHeader">
+                <complexType>
+                    <sequence>
+                        <element name="updateMru" type="xsd:boolean" />
+                    </sequence>
+                </complexType>
+    </element>
+
+    <element name="EmailHeader">
+                <complexType>
+                    <sequence>
+                        <element name="triggerAutoResponseEmail"    type="xsd:boolean"/>
+                        <element name="triggerOtherEmail"           type="xsd:boolean"/>
+                        <element name="triggerUserEmail"            type="xsd:boolean"/>
+                    </sequence>
+                </complexType>
+    </element>
+
+    <element name="AssignmentRuleHeader">
+                <complexType>
+                    <sequence>
+                        <element name="assignmentRuleId"    type="tns:ID"  nillable="true" />
+                        <element name="useDefaultRule"      type="xsd:boolean" nillable="true" />
+                    </sequence>
+                </complexType>
+    </element>
+
+            <element name="UserTerritoryDeleteHeader">
+                <complexType>
+                    <sequence>
+                        <element name="transferToUserId" type="tns:ID" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+            <element name="LocaleOptions">
+                <complexType>
+                    <sequence>
+                        <element name="language"  type="xsd:string" minOccurs="0"/>
+
+                        <element name="localizeErrors" type="xsd:boolean" minOccurs="0"/>
+
+                    </sequence>
+                </complexType>
+            </element>            
+
+                
+        <element name="OwnerChangeOptions">
+            <complexType>
+                <sequence>
+                
+                    <element name="transferAttachments" type="xsd:boolean"  />
+                    <element name="transferOpenActivities" type="xsd:boolean"  />
+                </sequence>
+            </complexType>
+        </element>
+
+        </schema>
+
+        <schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:fault.partner.soap.sforce.com" xmlns:fns="urn:fault.partner.soap.sforce.com">
+
+            <simpleType name="ExceptionCode">
+                <restriction base="xsd:string">
+                    <enumeration value="APEX_TRIGGER_COUPLING_LIMIT"/>
+                    <enumeration value="API_CURRENTLY_DISABLED"/>
+                    <enumeration value="API_DISABLED_FOR_ORG"/>
+                    <enumeration value="ARGUMENT_OBJECT_PARSE_ERROR"/>
+                    <enumeration value="ASYNC_OPERATION_LOCATOR"/>
+                    <enumeration value="BATCH_PROCESSING_HALTED"/>
+                    <enumeration value="BIG_OBJECT_UNSUPPORTED_OPERATION"/>
+                    <enumeration value="CANNOT_DELETE_ENTITY"/>
+                    <enumeration value="CANNOT_DELETE_OWNER"/>
+                    <enumeration value="CANT_ADD_STANDADRD_PORTAL_USER_TO_TERRITORY"/>
+                    <enumeration value="CANT_ADD_STANDARD_PORTAL_USER_TO_TERRITORY"/>
+                    <enumeration value="CIRCULAR_OBJECT_GRAPH"/>
+                    <enumeration value="CLIENT_NOT_ACCESSIBLE_FOR_USER"/>
+                    <enumeration value="CLIENT_REQUIRE_UPDATE_FOR_USER"/>
+                    <enumeration value="CONTENT_HUB_AUTHENTICATION_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_FILE_DOWNLOAD_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_FILE_NOT_FOUND_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_INVALID_OBJECT_TYPE_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_INVALID_PAGE_NUMBER_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_OPERATION_NOT_SUPPORTED_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_SECURITY_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_TIMEOUT_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_UNEXPECTED_EXCEPTION"/>
+                    <enumeration value="CUSTOM_METADATA_LIMIT_EXCEEDED"/>
+                    <enumeration value="CUSTOM_SETTINGS_LIMIT_EXCEEDED"/>
+                    <enumeration value="DATACLOUD_API_CLIENT_EXCEPTION"/>
+                    <enumeration value="DATACLOUD_API_DISABLED_EXCEPTION"/>
+                    <enumeration value="DATACLOUD_API_SERVER_BUSY_EXCEPTION"/>
+                    <enumeration value="DATACLOUD_API_SERVER_EXCEPTION"/>
+                    <enumeration value="DATACLOUD_API_TIMEOUT_EXCEPTION"/>
+                    <enumeration value="DATACLOUD_API_UNAVAILABLE"/>
+                    <enumeration value="DUPLICATE_ARGUMENT_VALUE"/>
+                    <enumeration value="DUPLICATE_VALUE"/>
+                    <enumeration value="EMAIL_BATCH_SIZE_LIMIT_EXCEEDED"/>
+                    <enumeration value="EMAIL_TO_CASE_INVALID_ROUTING"/>
+                    <enumeration value="EMAIL_TO_CASE_LIMIT_EXCEEDED"/>
+                    <enumeration value="EMAIL_TO_CASE_NOT_ENABLED"/>
+                    <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_CONFLICT"/>
+                    <enumeration value="EXCEEDED_ID_LIMIT"/>
+                    <enumeration value="EXCEEDED_LEAD_CONVERT_LIMIT"/>
+                    <enumeration value="EXCEEDED_MAX_SIZE_REQUEST"/>
+                    <enumeration value="EXCEEDED_MAX_TYPES_LIMIT"/>
+                    <enumeration value="EXCEEDED_QUOTA"/>
+                    <enumeration value="EXTERNAL_OBJECT_AUTHENTICATION_EXCEPTION"/>
+                    <enumeration value="EXTERNAL_OBJECT_CONNECTION_EXCEPTION"/>
+                    <enumeration value="EXTERNAL_OBJECT_EXCEPTION"/>
+                    <enumeration value="EXTERNAL_OBJECT_UNSUPPORTED_EXCEPTION"/>
+                    <enumeration value="FEDERATED_SEARCH_ERROR"/>
+                    <enumeration value="FEED_NOT_ENABLED_FOR_OBJECT"/>
+                    <enumeration value="FUNCTIONALITY_NOT_ENABLED"/>
+                    <enumeration value="FUNCTIONALITY_TEMPORARILY_UNAVAILABLE"/>
+                    <enumeration value="ILLEGAL_QUERY_PARAMETER_VALUE"/>
+                    <enumeration value="INACTIVE_OWNER_OR_USER"/>
+                    <enumeration value="INACTIVE_PORTAL"/>
+                    <enumeration value="INSUFFICIENT_ACCESS"/>
+                    <enumeration value="INTERNAL_CANVAS_ERROR"/>
+                    <enumeration value="INVALID_ASSIGNMENT_RULE"/>
+                    <enumeration value="INVALID_BATCH_REQUEST"/>
+                    <enumeration value="INVALID_BATCH_SIZE"/>
+                    <enumeration value="INVALID_CLIENT"/>
+                    <enumeration value="INVALID_CROSS_REFERENCE_KEY"/>
+                    <enumeration value="INVALID_DATE_FORMAT"/>
+                    <enumeration value="INVALID_FIELD"/>
+                    <enumeration value="INVALID_FILTER_LANGUAGE"/>
+                    <enumeration value="INVALID_FILTER_VALUE"/>
+                    <enumeration value="INVALID_ID_FIELD"/>
+                    <enumeration value="INVALID_INPUT_COMBINATION"/>
+                    <enumeration value="INVALID_LOCALE_LANGUAGE"/>
+                    <enumeration value="INVALID_LOCATOR"/>
+                    <enumeration value="INVALID_LOGIN"/>
+                    <enumeration value="INVALID_MULTIPART_REQUEST"/>
+                    <enumeration value="INVALID_NEW_PASSWORD"/>
+                    <enumeration value="INVALID_OPERATION"/>
+                    <enumeration value="INVALID_OPERATION_WITH_EXPIRED_PASSWORD"/>
+                    <enumeration value="INVALID_PACKAGE_VERSION"/>
+                    <enumeration value="INVALID_PAGING_OPTION"/>
+                    <enumeration value="INVALID_QUERY_FILTER_OPERATOR"/>
+                    <enumeration value="INVALID_QUERY_LOCATOR"/>
+                    <enumeration value="INVALID_QUERY_SCOPE"/>
+                    <enumeration value="INVALID_REPLICATION_DATE"/>
+                    <enumeration value="INVALID_SEARCH"/>
+                    <enumeration value="INVALID_SEARCH_SCOPE"/>
+                    <enumeration value="INVALID_SESSION_ID"/>
+                    <enumeration value="INVALID_SOAP_HEADER"/>
+                    <enumeration value="INVALID_SORT_OPTION"/>
+                    <enumeration value="INVALID_SSO_GATEWAY_URL"/>
+                    <enumeration value="INVALID_TYPE"/>
+                    <enumeration value="INVALID_TYPE_FOR_OPERATION"/>
+                    <enumeration value="JIGSAW_ACTION_DISABLED"/>
+                    <enumeration value="JIGSAW_IMPORT_LIMIT_EXCEEDED"/>
+                    <enumeration value="JIGSAW_REQUEST_NOT_SUPPORTED"/>
+                    <enumeration value="JSON_PARSER_ERROR"/>
+                    <enumeration value="KEY_HAS_BEEN_DESTROYED"/>
+                    <enumeration value="LICENSING_UNKNOWN_ERROR"/>
+                    <enumeration value="LIMIT_EXCEEDED"/>
+                    <enumeration value="LOGIN_CHALLENGE_ISSUED"/>
+                    <enumeration value="LOGIN_CHALLENGE_PENDING"/>
+                    <enumeration value="LOGIN_DURING_RESTRICTED_DOMAIN"/>
+                    <enumeration value="LOGIN_DURING_RESTRICTED_TIME"/>
+                    <enumeration value="LOGIN_MUST_USE_SECURITY_TOKEN"/>
+                    <enumeration value="MALFORMED_ID"/>
+                    <enumeration value="MALFORMED_QUERY"/>
+                    <enumeration value="MALFORMED_SEARCH"/>
+                    <enumeration value="MISSING_ARGUMENT"/>
+                    <enumeration value="MISSING_RECORD"/>
+                    <enumeration value="MUTUAL_AUTHENTICATION_FAILED"/>
+                    <enumeration value="NOT_ACCEPTABLE"/>
+                    <enumeration value="NOT_MODIFIED"/>
+                    <enumeration value="NO_SOFTPHONE_LAYOUT"/>
+                    <enumeration value="NUMBER_OUTSIDE_VALID_RANGE"/>
+                    <enumeration value="OPERATION_TOO_LARGE"/>
+                    <enumeration value="ORG_IN_MAINTENANCE"/>
+                    <enumeration value="ORG_IS_DOT_ORG"/>
+                    <enumeration value="ORG_IS_SIGNING_UP"/>
+                    <enumeration value="ORG_LOCKED"/>
+                    <enumeration value="ORG_NOT_OWNED_BY_INSTANCE"/>
+                    <enumeration value="PASSWORD_LOCKOUT"/>
+                    <enumeration value="PORTAL_NO_ACCESS"/>
+                    <enumeration value="POST_BODY_PARSE_ERROR"/>
+                    <enumeration value="QUERY_TIMEOUT"/>
+                    <enumeration value="QUERY_TOO_COMPLICATED"/>
+                    <enumeration value="REQUEST_LIMIT_EXCEEDED"/>
+                    <enumeration value="REQUEST_RUNNING_TOO_LONG"/>
+                    <enumeration value="SERVER_UNAVAILABLE"/>
+                    <enumeration value="SERVICE_DESK_NOT_ENABLED"/>
+                    <enumeration value="SOCIALCRM_FEEDSERVICE_API_CLIENT_EXCEPTION"/>
+                    <enumeration value="SOCIALCRM_FEEDSERVICE_API_SERVER_EXCEPTION"/>
+                    <enumeration value="SOCIALCRM_FEEDSERVICE_API_UNAVAILABLE"/>
+                    <enumeration value="SSO_SERVICE_DOWN"/>
+                    <enumeration value="SST_ADMIN_FILE_DOWNLOAD_EXCEPTION"/>
+                    <enumeration value="TOO_MANY_APEX_REQUESTS"/>
+                    <enumeration value="TOO_MANY_RECIPIENTS"/>
+                    <enumeration value="TOO_MANY_RECORDS"/>
+                    <enumeration value="TRIAL_EXPIRED"/>
+                    <enumeration value="TXN_SECURITY_END_A_SESSION"/>
+                    <enumeration value="TXN_SECURITY_NO_ACCESS"/>
+                    <enumeration value="TXN_SECURITY_TWO_FA_REQUIRED"/>
+                    <enumeration value="UNABLE_TO_LOCK_ROW"/>
+                    <enumeration value="UNKNOWN_ATTACHMENT_EXCEPTION"/>
+                    <enumeration value="UNKNOWN_EXCEPTION"/>
+                    <enumeration value="UNSUPPORTED_API_VERSION"/>
+                    <enumeration value="UNSUPPORTED_ATTACHMENT_ENCODING"/>
+                    <enumeration value="UNSUPPORTED_CLIENT"/>
+                    <enumeration value="UNSUPPORTED_MEDIA_TYPE"/>
+                    <enumeration value="XML_PARSER_ERROR"/>
+                </restriction>
+            </simpleType>
+            <!-- For convenience these QNames are returned in the standard soap faultcode element -->
+            <simpleType name="FaultCode">
+                <restriction base="xsd:QName">
+                    <enumeration value="fns:APEX_TRIGGER_COUPLING_LIMIT"/>
+                    <enumeration value="fns:API_CURRENTLY_DISABLED"/>
+                    <enumeration value="fns:API_DISABLED_FOR_ORG"/>
+                    <enumeration value="fns:ARGUMENT_OBJECT_PARSE_ERROR"/>
+                    <enumeration value="fns:ASYNC_OPERATION_LOCATOR"/>
+                    <enumeration value="fns:BATCH_PROCESSING_HALTED"/>
+                    <enumeration value="fns:BIG_OBJECT_UNSUPPORTED_OPERATION"/>
+                    <enumeration value="fns:CANNOT_DELETE_ENTITY"/>
+                    <enumeration value="fns:CANNOT_DELETE_OWNER"/>
+                    <enumeration value="fns:CANT_ADD_STANDADRD_PORTAL_USER_TO_TERRITORY"/>
+                    <enumeration value="fns:CANT_ADD_STANDARD_PORTAL_USER_TO_TERRITORY"/>
+                    <enumeration value="fns:CIRCULAR_OBJECT_GRAPH"/>
+                    <enumeration value="fns:CLIENT_NOT_ACCESSIBLE_FOR_USER"/>
+                    <enumeration value="fns:CLIENT_REQUIRE_UPDATE_FOR_USER"/>
+                    <enumeration value="fns:CONTENT_HUB_AUTHENTICATION_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_FILE_DOWNLOAD_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_FILE_NOT_FOUND_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_INVALID_OBJECT_TYPE_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_INVALID_PAGE_NUMBER_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_OPERATION_NOT_SUPPORTED_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_SECURITY_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_TIMEOUT_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_UNEXPECTED_EXCEPTION"/>
+                    <enumeration value="fns:CUSTOM_METADATA_LIMIT_EXCEEDED"/>
+                    <enumeration value="fns:CUSTOM_SETTINGS_LIMIT_EXCEEDED"/>
+                    <enumeration value="fns:DATACLOUD_API_CLIENT_EXCEPTION"/>
+                    <enumeration value="fns:DATACLOUD_API_DISABLED_EXCEPTION"/>
+                    <enumeration value="fns:DATACLOUD_API_SERVER_BUSY_EXCEPTION"/>
+                    <enumeration value="fns:DATACLOUD_API_SERVER_EXCEPTION"/>
+                    <enumeration value="fns:DATACLOUD_API_TIMEOUT_EXCEPTION"/>
+                    <enumeration value="fns:DATACLOUD_API_UNAVAILABLE"/>
+                    <enumeration value="fns:DUPLICATE_ARGUMENT_VALUE"/>
+                    <enumeration value="fns:DUPLICATE_VALUE"/>
+                    <enumeration value="fns:EMAIL_BATCH_SIZE_LIMIT_EXCEEDED"/>
+                    <enumeration value="fns:EMAIL_TO_CASE_INVALID_ROUTING"/>
+                    <enumeration value="fns:EMAIL_TO_CASE_LIMIT_EXCEEDED"/>
+                    <enumeration value="fns:EMAIL_TO_CASE_NOT_ENABLED"/>
+                    <enumeration value="fns:ENVIRONMENT_HUB_MEMBERSHIP_CONFLICT"/>
+                    <enumeration value="fns:EXCEEDED_ID_LIMIT"/>
+                    <enumeration value="fns:EXCEEDED_LEAD_CONVERT_LIMIT"/>
+                    <enumeration value="fns:EXCEEDED_MAX_SIZE_REQUEST"/>
+                    <enumeration value="fns:EXCEEDED_MAX_TYPES_LIMIT"/>
+                    <enumeration value="fns:EXCEEDED_QUOTA"/>
+                    <enumeration value="fns:EXTERNAL_OBJECT_AUTHENTICATION_EXCEPTION"/>
+                    <enumeration value="fns:EXTERNAL_OBJECT_CONNECTION_EXCEPTION"/>
+                    <enumeration value="fns:EXTERNAL_OBJECT_EXCEPTION"/>
+                    <enumeration value="fns:EXTERNAL_OBJECT_UNSUPPORTED_EXCEPTION"/>
+                    <enumeration value="fns:FEDERATED_SEARCH_ERROR"/>
+                    <enumeration value="fns:FEED_NOT_ENABLED_FOR_OBJECT"/>
+                    <enumeration value="fns:FUNCTIONALITY_NOT_ENABLED"/>
+                    <enumeration value="fns:FUNCTIONALITY_TEMPORARILY_UNAVAILABLE"/>
+                    <enumeration value="fns:ILLEGAL_QUERY_PARAMETER_VALUE"/>
+                    <enumeration value="fns:INACTIVE_OWNER_OR_USER"/>
+                    <enumeration value="fns:INACTIVE_PORTAL"/>
+                    <enumeration value="fns:INSUFFICIENT_ACCESS"/>
+                    <enumeration value="fns:INTERNAL_CANVAS_ERROR"/>
+                    <enumeration value="fns:INVALID_ASSIGNMENT_RULE"/>
+                    <enumeration value="fns:INVALID_BATCH_REQUEST"/>
+                    <enumeration value="fns:INVALID_BATCH_SIZE"/>
+                    <enumeration value="fns:INVALID_CLIENT"/>
+                    <enumeration value="fns:INVALID_CROSS_REFERENCE_KEY"/>
+                    <enumeration value="fns:INVALID_DATE_FORMAT"/>
+                    <enumeration value="fns:INVALID_FIELD"/>
+                    <enumeration value="fns:INVALID_FILTER_LANGUAGE"/>
+                    <enumeration value="fns:INVALID_FILTER_VALUE"/>
+                    <enumeration value="fns:INVALID_ID_FIELD"/>
+                    <enumeration value="fns:INVALID_INPUT_COMBINATION"/>
+                    <enumeration value="fns:INVALID_LOCALE_LANGUAGE"/>
+                    <enumeration value="fns:INVALID_LOCATOR"/>
+                    <enumeration value="fns:INVALID_LOGIN"/>
+                    <enumeration value="fns:INVALID_MULTIPART_REQUEST"/>
+                    <enumeration value="fns:INVALID_NEW_PASSWORD"/>
+                    <enumeration value="fns:INVALID_OPERATION"/>
+                    <enumeration value="fns:INVALID_OPERATION_WITH_EXPIRED_PASSWORD"/>
+                    <enumeration value="fns:INVALID_PACKAGE_VERSION"/>
+                    <enumeration value="fns:INVALID_PAGING_OPTION"/>
+                    <enumeration value="fns:INVALID_QUERY_FILTER_OPERATOR"/>
+                    <enumeration value="fns:INVALID_QUERY_LOCATOR"/>
+                    <enumeration value="fns:INVALID_QUERY_SCOPE"/>
+                    <enumeration value="fns:INVALID_REPLICATION_DATE"/>
+                    <enumeration value="fns:INVALID_SEARCH"/>
+                    <enumeration value="fns:INVALID_SEARCH_SCOPE"/>
+                    <enumeration value="fns:INVALID_SESSION_ID"/>
+                    <enumeration value="fns:INVALID_SOAP_HEADER"/>
+                    <enumeration value="fns:INVALID_SORT_OPTION"/>
+                    <enumeration value="fns:INVALID_SSO_GATEWAY_URL"/>
+                    <enumeration value="fns:INVALID_TYPE"/>
+                    <enumeration value="fns:INVALID_TYPE_FOR_OPERATION"/>
+                    <enumeration value="fns:JIGSAW_ACTION_DISABLED"/>
+                    <enumeration value="fns:JIGSAW_IMPORT_LIMIT_EXCEEDED"/>
+                    <enumeration value="fns:JIGSAW_REQUEST_NOT_SUPPORTED"/>
+                    <enumeration value="fns:JSON_PARSER_ERROR"/>
+                    <enumeration value="fns:KEY_HAS_BEEN_DESTROYED"/>
+                    <enumeration value="fns:LICENSING_UNKNOWN_ERROR"/>
+                    <enumeration value="fns:LIMIT_EXCEEDED"/>
+                    <enumeration value="fns:LOGIN_CHALLENGE_ISSUED"/>
+                    <enumeration value="fns:LOGIN_CHALLENGE_PENDING"/>
+                    <enumeration value="fns:LOGIN_DURING_RESTRICTED_DOMAIN"/>
+                    <enumeration value="fns:LOGIN_DURING_RESTRICTED_TIME"/>
+                    <enumeration value="fns:LOGIN_MUST_USE_SECURITY_TOKEN"/>
+                    <enumeration value="fns:MALFORMED_ID"/>
+                    <enumeration value="fns:MALFORMED_QUERY"/>
+                    <enumeration value="fns:MALFORMED_SEARCH"/>
+                    <enumeration value="fns:MISSING_ARGUMENT"/>
+                    <enumeration value="fns:MISSING_RECORD"/>
+                    <enumeration value="fns:MUTUAL_AUTHENTICATION_FAILED"/>
+                    <enumeration value="fns:NOT_ACCEPTABLE"/>
+                    <enumeration value="fns:NOT_MODIFIED"/>
+                    <enumeration value="fns:NO_SOFTPHONE_LAYOUT"/>
+                    <enumeration value="fns:NUMBER_OUTSIDE_VALID_RANGE"/>
+                    <enumeration value="fns:OPERATION_TOO_LARGE"/>
+                    <enumeration value="fns:ORG_IN_MAINTENANCE"/>
+                    <enumeration value="fns:ORG_IS_DOT_ORG"/>
+                    <enumeration value="fns:ORG_IS_SIGNING_UP"/>
+                    <enumeration value="fns:ORG_LOCKED"/>
+                    <enumeration value="fns:ORG_NOT_OWNED_BY_INSTANCE"/>
+                    <enumeration value="fns:PASSWORD_LOCKOUT"/>
+                    <enumeration value="fns:PORTAL_NO_ACCESS"/>
+                    <enumeration value="fns:POST_BODY_PARSE_ERROR"/>
+                    <enumeration value="fns:QUERY_TIMEOUT"/>
+                    <enumeration value="fns:QUERY_TOO_COMPLICATED"/>
+                    <enumeration value="fns:REQUEST_LIMIT_EXCEEDED"/>
+                    <enumeration value="fns:REQUEST_RUNNING_TOO_LONG"/>
+                    <enumeration value="fns:SERVER_UNAVAILABLE"/>
+                    <enumeration value="fns:SERVICE_DESK_NOT_ENABLED"/>
+                    <enumeration value="fns:SOCIALCRM_FEEDSERVICE_API_CLIENT_EXCEPTION"/>
+                    <enumeration value="fns:SOCIALCRM_FEEDSERVICE_API_SERVER_EXCEPTION"/>
+                    <enumeration value="fns:SOCIALCRM_FEEDSERVICE_API_UNAVAILABLE"/>
+                    <enumeration value="fns:SSO_SERVICE_DOWN"/>
+                    <enumeration value="fns:SST_ADMIN_FILE_DOWNLOAD_EXCEPTION"/>
+                    <enumeration value="fns:TOO_MANY_APEX_REQUESTS"/>
+                    <enumeration value="fns:TOO_MANY_RECIPIENTS"/>
+                    <enumeration value="fns:TOO_MANY_RECORDS"/>
+                    <enumeration value="fns:TRIAL_EXPIRED"/>
+                    <enumeration value="fns:TXN_SECURITY_END_A_SESSION"/>
+                    <enumeration value="fns:TXN_SECURITY_NO_ACCESS"/>
+                    <enumeration value="fns:TXN_SECURITY_TWO_FA_REQUIRED"/>
+                    <enumeration value="fns:UNABLE_TO_LOCK_ROW"/>
+                    <enumeration value="fns:UNKNOWN_ATTACHMENT_EXCEPTION"/>
+                    <enumeration value="fns:UNKNOWN_EXCEPTION"/>
+                    <enumeration value="fns:UNSUPPORTED_API_VERSION"/>
+                    <enumeration value="fns:UNSUPPORTED_ATTACHMENT_ENCODING"/>
+                    <enumeration value="fns:UNSUPPORTED_CLIENT"/>
+                    <enumeration value="fns:UNSUPPORTED_MEDIA_TYPE"/>
+                    <enumeration value="fns:XML_PARSER_ERROR"/>
+                </restriction>
+            </simpleType>
+
+
+            <!-- Fault -->
+            <complexType name="ApiFault">
+                <sequence>
+                    <element name="exceptionCode"    type="fns:ExceptionCode"/>
+                    <element name="exceptionMessage" type="xsd:string"/>
+
+                </sequence>
+            </complexType>
+
+            <element name="fault" type="fns:ApiFault" />
+
+            <complexType name="ApiQueryFault">
+                <complexContent>
+                    <extension base="fns:ApiFault">
+                        <sequence>
+                        <element name="row" type="xsd:int"/>
+                        <element name="column" type="xsd:int"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="LoginFault">
+                <complexContent>
+                    <extension base="fns:ApiFault"/>
+                </complexContent>
+            </complexType>
+            <element name="LoginFault" type="fns:LoginFault"/>
+
+            <complexType name="InvalidQueryLocatorFault">
+                <complexContent>
+                    <extension base="fns:ApiFault"/>
+                </complexContent>
+            </complexType>
+            <element name="InvalidQueryLocatorFault" type="fns:InvalidQueryLocatorFault"/>
+
+            <complexType name="InvalidNewPasswordFault">
+                <complexContent>
+                    <extension base="fns:ApiFault"/>
+                </complexContent>
+            </complexType>
+            <element name="InvalidNewPasswordFault" type="fns:InvalidNewPasswordFault"/>
+
+            <complexType name="InvalidIdFault">
+                <complexContent>
+                    <extension base="fns:ApiFault"/>
+                </complexContent>
+            </complexType>
+            <element name="InvalidIdFault" type="fns:InvalidIdFault"/>
+
+            <complexType name="UnexpectedErrorFault">
+                <complexContent>
+                    <extension base="fns:ApiFault"/>
+                </complexContent>
+            </complexType>
+            <element name="UnexpectedErrorFault" type="fns:UnexpectedErrorFault"/>
+
+            <complexType name="InvalidFieldFault">
+                <complexContent>
+                    <extension base="fns:ApiQueryFault"/>
+                </complexContent>
+            </complexType>
+            <element name="InvalidFieldFault" type="fns:InvalidFieldFault"/>
+
+            <complexType name="InvalidSObjectFault">
+                <complexContent>
+                    <extension base="fns:ApiQueryFault"/>
+                </complexContent>
+            </complexType>
+            <element name="InvalidSObjectFault" type="fns:InvalidSObjectFault"/>
+
+            <complexType name="MalformedQueryFault">
+                <complexContent>
+                    <extension base="fns:ApiQueryFault"/>
+                </complexContent>
+            </complexType>
+            <element name="MalformedQueryFault" type="fns:MalformedQueryFault"/>
+
+            <complexType name="MalformedSearchFault">
+                <complexContent>
+                    <extension base="fns:ApiQueryFault"/>
+                </complexContent>
+            </complexType>
+            <element name="MalformedSearchFault" type="fns:MalformedSearchFault"/>
+
+
+        </schema>
+    </types>
+
+    <!-- Header Message -->
+    <message name="Header">
+        <part element="tns:LoginScopeHeader"             name="LoginScopeHeader"/>
+        <part element="tns:SessionHeader"                name="SessionHeader"/>
+
+        <part element="tns:CallOptions"                  name="CallOptions"/>
+
+        <part element="tns:QueryOptions"                 name="QueryOptions"/>
+        <part element="tns:AssignmentRuleHeader"         name="AssignmentRuleHeader"/>
+        <part element="tns:AllowFieldTruncationHeader"   name="AllowFieldTruncationHeader"/>
+
+        <part element="tns:AllOrNoneHeader"              name="AllOrNoneHeader"/>
+
+
+
+
+        <part element="tns:DuplicateRuleHeader"          name="DuplicateRuleHeader"/>
+
+
+
+        <part element="tns:DisableFeedTrackingHeader"    name="DisableFeedTrackingHeader"/>
+
+
+        <part element="tns:StreamingEnabledHeader"       name="StreamingEnabledHeader"/>
+
+        <part element="tns:MruHeader"                    name="MruHeader"/>
+        <part element="tns:EmailHeader"                  name="EmailHeader"/>
+
+        <part element="tns:UserTerritoryDeleteHeader"    name="UserTerritoryDeleteHeader"/>
+
+        <part element="tns:DebuggingHeader"              name="DebuggingHeader"/>
+        <part element="tns:PackageVersionHeader"         name="PackageVersionHeader"/>
+        <part element="tns:DebuggingInfo"                name="DebuggingInfo"/>
+
+        <part element="tns:LimitInfoHeader"              name="LimitInfoHeader"/>
+
+        <part element="tns:LocaleOptions"                name="LocaleOptions"/>
+
+        <part element="tns:OwnerChangeOptions"           name="OwnerChangeOptions"/>
+
+    </message>
+
+    <!-- Fault Messages -->
+
+    <message name="ApiFault">
+        <part name="fault" element="fns:fault"/>
+    </message>
+
+    <message name="LoginFault">
+        <part name="fault" element="fns:LoginFault"/>
+    </message>
+    <message name="InvalidQueryLocatorFault">
+        <part name="fault" element="fns:InvalidQueryLocatorFault"/>
+    </message>
+    <message name="InvalidNewPasswordFault">
+        <part name="fault" element="fns:InvalidNewPasswordFault"/>
+    </message>
+    <message name="InvalidIdFault">
+        <part name="fault" element="fns:InvalidIdFault"/>
+    </message>
+    <message name="UnexpectedErrorFault">
+        <part name="fault" element="fns:UnexpectedErrorFault"/>
+    </message>
+    <message name="InvalidFieldFault">
+        <part name="fault" element="fns:InvalidFieldFault"/>
+    </message>
+    <message name="InvalidSObjectFault">
+        <part name="fault" element="fns:InvalidSObjectFault"/>
+    </message>
+    <message name="MalformedQueryFault">
+        <part name="fault" element="fns:MalformedQueryFault"/>
+    </message>
+    <message name="MalformedSearchFault">
+        <part name="fault" element="fns:MalformedSearchFault"/>
+    </message>
+
+
+    <!-- Method Messages -->
+    <message name="loginRequest">
+        <part element="tns:login" name="parameters"/>
+    </message>
+    <message name="loginResponse">
+        <part element="tns:loginResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSObjectRequest">
+        <part element="tns:describeSObject" name="parameters"/>
+    </message>
+    <message name="describeSObjectResponse">
+        <part element="tns:describeSObjectResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSObjectsRequest">
+        <part element="tns:describeSObjects" name="parameters"/>
+    </message>
+    <message name="describeSObjectsResponse">
+        <part element="tns:describeSObjectsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeGlobalRequest">
+        <part element="tns:describeGlobal" name="parameters"/>
+    </message>
+    <message name="describeGlobalResponse">
+        <part element="tns:describeGlobalResponse" name="parameters"/>
+    </message>
+
+    <message name="describeDataCategoryGroupsRequest">
+        <part element="tns:describeDataCategoryGroups" name="parameters"/>
+    </message>
+    <message name="describeDataCategoryGroupsResponse">
+        <part element="tns:describeDataCategoryGroupsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeDataCategoryGroupStructuresRequest">
+        <part element="tns:describeDataCategoryGroupStructures" name="parameters"/>
+    </message>
+    <message name="describeDataCategoryGroupStructuresResponse">
+        <part element="tns:describeDataCategoryGroupStructuresResponse" name="parameters"/>
+    </message>
+
+    <message name="describeKnowledgeSettingsRequest">
+        <part element="tns:describeKnowledgeSettings" name="parameters"/>
+    </message>
+    <message name="describeKnowledgeSettingsResponse">
+        <part element="tns:describeKnowledgeSettingsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeFlexiPagesRequest">
+        <part element="tns:describeFlexiPages" name="parameters"/>
+    </message>
+    <message name="describeFlexiPagesResponse">
+        <part element="tns:describeFlexiPagesResponse" name="parameters"/>
+    </message>
+
+    <message name="describeAppMenuRequest">
+        <part element="tns:describeAppMenu" name="parameters"/>
+    </message>
+    <message name="describeAppMenuResponse">
+        <part element="tns:describeAppMenuResponse" name="parameters"/>
+    </message>
+
+    <message name="describeGlobalThemeRequest">
+        <part element="tns:describeGlobalTheme" name="parameters"/>
+    </message>
+    <message name="describeGlobalThemeResponse">
+        <part element="tns:describeGlobalThemeResponse" name="parameters"/>
+    </message>
+
+    <message name="describeThemeRequest">
+        <part element="tns:describeTheme" name="parameters"/>
+    </message>
+    <message name="describeThemeResponse">
+        <part element="tns:describeThemeResponse" name="parameters"/>
+    </message>
+
+    <message name="describeLayoutRequest">
+        <part element="tns:describeLayout" name="parameters"/>
+    </message>
+    <message name="describeLayoutResponse">
+        <part element="tns:describeLayoutResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSoftphoneLayoutRequest">
+        <part element="tns:describeSoftphoneLayout" name="parameters"/>
+    </message>
+    <message name="describeSoftphoneLayoutResponse">
+        <part element="tns:describeSoftphoneLayoutResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSearchLayoutsRequest">
+        <part element="tns:describeSearchLayouts" name="parameters"/>
+    </message>
+    <message name="describeSearchLayoutsResponse">
+        <part element="tns:describeSearchLayoutsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSearchScopeOrderRequest">
+        <part element="tns:describeSearchScopeOrder" name="parameters"/>
+    </message>
+    <message name="describeSearchScopeOrderResponse">
+        <part element="tns:describeSearchScopeOrderResponse" name="parameters"/>
+    </message>
+
+    <message name="describeCompactLayoutsRequest">
+        <part element="tns:describeCompactLayouts" name="parameters"/>
+    </message>
+    <message name="describeCompactLayoutsResponse">
+        <part element="tns:describeCompactLayoutsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeApprovalLayoutRequest">
+        <part element="tns:describeApprovalLayout" name="parameters"/>
+    </message>
+    <message name="describeApprovalLayoutResponse">
+        <part element="tns:describeApprovalLayoutResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSoqlListViewsRequest">
+        <part element="tns:describeSoqlListViews" name="parameters"/>
+    </message>
+    <message name="describeSoqlListViewsResponse">
+        <part element="tns:describeSoqlListViewsResponse" name="parameters"/>
+    </message>
+
+    <message name="executeListViewRequest">
+        <part element="tns:executeListView" name="parameters"/>
+    </message>
+    <message name="executeListViewResponse">
+        <part element="tns:executeListViewResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSObjectListViewsRequest">
+        <part element="tns:describeSObjectListViews" name="parameters"/>
+    </message>
+    <message name="describeSObjectListViewsResponse">
+        <part element="tns:describeSObjectListViewsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeTabsRequest">
+        <part element="tns:describeTabs" name="parameters"/>
+    </message>
+    <message name="describeTabsResponse">
+        <part element="tns:describeTabsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeAllTabsRequest">
+        <part element="tns:describeAllTabs" name="parameters"/>
+    </message>
+    <message name="describeAllTabsResponse">
+        <part element="tns:describeAllTabsResponse" name="parameters"/>
+    </message>
+
+    <message name="describePrimaryCompactLayoutsRequest">
+        <part element="tns:describePrimaryCompactLayouts" name="parameters"/>
+    </message>
+    <message name="describePrimaryCompactLayoutsResponse">
+        <part element="tns:describePrimaryCompactLayoutsResponse" name="parameters"/>
+    </message>
+
+    <message name="createRequest">
+        <part element="tns:create" name="parameters"/>
+    </message>
+    <message name="createResponse">
+        <part element="tns:createResponse" name="parameters"/>
+    </message>
+
+    <message name="updateRequest">
+        <part element="tns:update" name="parameters"/>
+    </message>
+    <message name="updateResponse">
+        <part element="tns:updateResponse" name="parameters"/>
+    </message>
+
+    <message name="upsertRequest">
+        <part element="tns:upsert" name="parameters"/>
+    </message>
+    <message name="upsertResponse">
+        <part element="tns:upsertResponse" name="parameters"/>
+    </message>
+
+    <message name="mergeRequest">
+        <part element="tns:merge" name="parameters"/>
+    </message>
+    <message name="mergeResponse">
+        <part element="tns:mergeResponse" name="parameters"/>
+    </message>
+
+    <message name="deleteRequest">
+        <part element="tns:delete" name="parameters"/>
+    </message>
+    <message name="deleteResponse">
+        <part element="tns:deleteResponse" name="parameters"/>
+    </message>
+
+    <message name="undeleteRequest">
+        <part element="tns:undelete" name="parameters"/>
+    </message>
+    <message name="undeleteResponse">
+        <part element="tns:undeleteResponse" name="parameters"/>
+    </message>
+
+    <message name="emptyRecycleBinRequest">
+        <part element="tns:emptyRecycleBin" name="parameters"/>
+    </message>
+    <message name="emptyRecycleBinResponse">
+        <part element="tns:emptyRecycleBinResponse" name="parameters"/>
+    </message>
+
+    <message name="retrieveRequest">
+        <part element="tns:retrieve" name="parameters"/>
+    </message>
+    <message name="retrieveResponse">
+        <part element="tns:retrieveResponse" name="parameters"/>
+    </message>
+
+    <message name="processRequest">
+        <part element="tns:process" name="parameters"/>
+    </message>
+    <message name="processResponse">
+        <part element="tns:processResponse" name="parameters"/>
+    </message>
+
+    <message name="convertLeadRequest">
+        <part element="tns:convertLead" name="parameters"/>
+    </message>
+    <message name="convertLeadResponse">
+        <part element="tns:convertLeadResponse" name="parameters"/>
+    </message>
+
+    <message name="logoutRequest">
+        <part element="tns:logout" name="parameters"/>
+    </message>
+    <message name="logoutResponse">
+        <part element="tns:logoutResponse" name="parameters"/>
+    </message>
+
+    <message name="invalidateSessionsRequest">
+        <part element="tns:invalidateSessions" name="parameters"/>
+    </message>
+    <message name="invalidateSessionsResponse">
+        <part element="tns:invalidateSessionsResponse" name="parameters"/>
+    </message>
+
+    <message name="getDeletedRequest">
+        <part element="tns:getDeleted" name="parameters"/>
+    </message>
+    <message name="getDeletedResponse">
+        <part element="tns:getDeletedResponse" name="parameters"/>
+    </message>
+
+    <message name="getUpdatedRequest">
+        <part element="tns:getUpdated" name="parameters"/>
+    </message>
+    <message name="getUpdatedResponse">
+        <part element="tns:getUpdatedResponse" name="parameters"/>
+    </message>
+
+    <message name="queryRequest">
+        <part element="tns:query" name="parameters"/>
+    </message>
+    <message name="queryResponse">
+        <part element="tns:queryResponse" name="parameters"/>
+    </message>
+
+    <message name="queryAllRequest">
+        <part element="tns:queryAll" name="parameters"/>
+    </message>
+    <message name="queryAllResponse">
+        <part element="tns:queryAllResponse" name="parameters"/>
+    </message>
+
+    <message name="queryMoreRequest">
+        <part element="tns:queryMore" name="parameters"/>
+    </message>
+    <message name="queryMoreResponse">
+        <part element="tns:queryMoreResponse" name="parameters"/>
+    </message>
+
+    <message name="searchRequest">
+        <part element="tns:search" name="parameters"/>
+    </message>
+    <message name="searchResponse">
+        <part element="tns:searchResponse" name="parameters"/>
+    </message>
+
+    <message name="getServerTimestampRequest">
+        <part element="tns:getServerTimestamp" name="parameters"/>
+    </message>
+    <message name="getServerTimestampResponse">
+        <part element="tns:getServerTimestampResponse" name="parameters"/>
+    </message>
+
+    <message name="setPasswordRequest">
+        <part element="tns:setPassword" name="parameters"/>
+    </message>
+    <message name="setPasswordResponse">
+        <part element="tns:setPasswordResponse" name="parameters"/>
+    </message>
+
+    <message name="resetPasswordRequest">
+        <part element="tns:resetPassword" name="parameters"/>
+    </message>
+    <message name="resetPasswordResponse">
+        <part element="tns:resetPasswordResponse" name="parameters"/>
+    </message>
+
+    <message name="getUserInfoRequest">
+        <part element="tns:getUserInfo" name="parameters"/>
+    </message>
+    <message name="getUserInfoResponse">
+        <part element="tns:getUserInfoResponse" name="parameters"/>
+    </message>
+
+    <message name="sendEmailMessageRequest">
+        <part element="tns:sendEmailMessage" name="parameters"/>
+    </message>
+    <message name="sendEmailMessageResponse">
+        <part element="tns:sendEmailMessageResponse" name="parameters"/>
+    </message>
+
+    <message name="sendEmailRequest">
+        <part element="tns:sendEmail" name="parameters"/>
+    </message>
+    <message name="sendEmailResponse">
+        <part element="tns:sendEmailResponse" name="parameters"/>
+    </message>
+
+    <message name="performQuickActionsRequest">
+        <part element="tns:performQuickActions" name="parameters"/>
+    </message>
+    <message name="performQuickActionsResponse">
+        <part element="tns:performQuickActionsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeQuickActionsRequest">
+        <part element="tns:describeQuickActions" name="parameters"/>
+    </message>
+    <message name="describeQuickActionsResponse">
+        <part element="tns:describeQuickActionsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeAvailableQuickActionsRequest">
+        <part element="tns:describeAvailableQuickActions" name="parameters"/>
+    </message>
+    <message name="describeAvailableQuickActionsResponse">
+        <part element="tns:describeAvailableQuickActionsResponse" name="parameters"/>
+    </message>
+
+    <message name="retrieveQuickActionTemplatesRequest">
+        <part element="tns:retrieveQuickActionTemplates" name="parameters"/>
+    </message>
+    <message name="retrieveQuickActionTemplatesResponse">
+        <part element="tns:retrieveQuickActionTemplatesResponse" name="parameters"/>
+    </message>
+
+    <message name="describeNounsRequest">
+        <part element="tns:describeNouns" name="parameters"/>
+    </message>
+    <message name="describeNounsResponse">
+        <part element="tns:describeNounsResponse" name="parameters"/>
+    </message>
+
+
+
+    <!-- Soap PortType -->
+    <portType name="Soap">
+        <operation name="login">
+            <documentation>Login to the Salesforce.com SOAP Api</documentation>
+            <input  message="tns:loginRequest"/>
+            <output message="tns:loginResponse"/>
+            <fault  message="tns:LoginFault" name="LoginFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+        </operation>
+
+        <operation name="describeSObject">
+            <documentation>Describe an sObject</documentation>
+            <input  message="tns:describeSObjectRequest"/>
+            <output message="tns:describeSObjectResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeSObjects">
+            <documentation>Describe a number sObjects</documentation>
+            <input  message="tns:describeSObjectsRequest"/>
+            <output message="tns:describeSObjectsResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeGlobal">
+            <documentation>Describe the Global state</documentation>
+            <input  message="tns:describeGlobalRequest"/>
+            <output message="tns:describeGlobalResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeDataCategoryGroups">
+            <documentation>Describe all the data category groups available for a given set of types</documentation>
+            <input  message="tns:describeDataCategoryGroupsRequest"/>
+            <output message="tns:describeDataCategoryGroupsResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeDataCategoryGroupStructures">
+            <documentation>Describe the data category group structures for a given set of pair of types and data category group name</documentation>
+            <input  message="tns:describeDataCategoryGroupStructuresRequest"/>
+            <output message="tns:describeDataCategoryGroupStructuresResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeKnowledgeSettings">
+            <documentation>Describes your Knowledge settings, such as if knowledgeEnabled is on or off, its default language and supported languages</documentation>
+            <input  message="tns:describeKnowledgeSettingsRequest"/>
+            <output message="tns:describeKnowledgeSettingsResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeFlexiPages">
+            <documentation>Describe a list of FlexiPage and their contents</documentation>
+            <input  message="tns:describeFlexiPagesRequest"/>
+            <output message="tns:describeFlexiPagesResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+        </operation>
+
+        <operation name="describeAppMenu">
+            <documentation>Describe the items in an AppMenu</documentation>
+            <input  message="tns:describeAppMenuRequest"/>
+            <output message="tns:describeAppMenuResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeGlobalTheme">
+            <documentation>Describe Gloal and Themes</documentation>
+            <input  message="tns:describeGlobalThemeRequest"/>
+            <output message="tns:describeGlobalThemeResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeTheme">
+            <documentation>Describe Themes</documentation>
+            <input  message="tns:describeThemeRequest"/>
+            <output message="tns:describeThemeResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeLayout">
+            <documentation>Describe the layout of the given sObject or the given actionable global page.</documentation>
+            <input  message="tns:describeLayoutRequest"/>
+            <output message="tns:describeLayoutResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+        </operation>
+
+        <operation name="describeSoftphoneLayout">
+            <documentation>Describe the layout of the SoftPhone</documentation>
+            <input  message="tns:describeSoftphoneLayoutRequest"/>
+            <output message="tns:describeSoftphoneLayoutResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeSearchLayouts">
+            <documentation>Describe the search view of an sObject</documentation>
+            <input  message="tns:describeSearchLayoutsRequest"/>
+            <output message="tns:describeSearchLayoutsResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeSearchScopeOrder">
+            <documentation>Describe a list of objects representing the order and scope of objects on a users search result page</documentation>
+            <input  message="tns:describeSearchScopeOrderRequest"/>
+            <output message="tns:describeSearchScopeOrderResponse"/>
+        </operation>
+
+        <operation name="describeCompactLayouts">
+            <documentation>Describe the compact layouts of the given sObject</documentation>
+            <input  message="tns:describeCompactLayoutsRequest"/>
+            <output message="tns:describeCompactLayoutsResponse"/>
+        </operation>
+
+        <operation name="describeApprovalLayout">
+            <documentation>Describe the approval layouts of the given sObject</documentation>
+            <input  message="tns:describeApprovalLayoutRequest"/>
+            <output message="tns:describeApprovalLayoutResponse"/>
+        </operation>
+
+        <operation name="describeSoqlListViews">
+            <documentation>Describe the ListViews as SOQL metadata for the generation of SOQL.</documentation>
+            <input  message="tns:describeSoqlListViewsRequest"/>
+            <output message="tns:describeSoqlListViewsResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="executeListView">
+            <documentation>Execute the specified list view and return the presentation-ready results.</documentation>
+            <input  message="tns:executeListViewRequest"/>
+            <output message="tns:executeListViewResponse"/>
+        </operation>
+
+        <operation name="describeSObjectListViews">
+            <documentation>Describe the ListViews of a SObject as SOQL metadata for the generation of SOQL.</documentation>
+            <input  message="tns:describeSObjectListViewsRequest"/>
+            <output message="tns:describeSObjectListViewsResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeTabs">
+            <documentation>Describe the tabs that appear on a users page</documentation>
+            <input  message="tns:describeTabsRequest"/>
+            <output message="tns:describeTabsResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeAllTabs">
+            <documentation>Describe all tabs available to a user</documentation>
+            <input  message="tns:describeAllTabsRequest"/>
+            <output message="tns:describeAllTabsResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describePrimaryCompactLayouts">
+            <documentation>Describe the primary compact layouts for the sObjects requested</documentation>
+            <input  message="tns:describePrimaryCompactLayoutsRequest"/>
+            <output message="tns:describePrimaryCompactLayoutsResponse"/>
+        </operation>
+
+        <operation name="create">
+            <documentation>Create a set of new sObjects</documentation>
+            <input  message="tns:createRequest"/>
+            <output message="tns:createResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+        </operation>
+
+        <operation name="update">
+            <documentation>Update a set of sObjects</documentation>
+            <input  message="tns:updateRequest"/>
+            <output message="tns:updateResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+        </operation>
+
+        <operation name="upsert">
+            <documentation>Update or insert a set of sObjects based on object id</documentation>
+            <input  message="tns:upsertRequest"/>
+            <output message="tns:upsertResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+        </operation>
+
+        <operation name="merge">
+            <documentation>Merge and update a set of sObjects based on object id</documentation>
+            <input  message="tns:mergeRequest"/>
+            <output message="tns:mergeResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+        </operation>
+
+        <operation name="delete">
+            <documentation>Delete a set of sObjects</documentation>
+            <input  message="tns:deleteRequest"/>
+            <output message="tns:deleteResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="undelete">
+            <documentation>Undelete a set of sObjects</documentation>
+            <input  message="tns:undeleteRequest"/>
+            <output message="tns:undeleteResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="emptyRecycleBin">
+            <documentation>Empty a set of sObjects from the recycle bin</documentation>
+            <input  message="tns:emptyRecycleBinRequest"/>
+            <output message="tns:emptyRecycleBinResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="retrieve">
+            <documentation>Get a set of sObjects</documentation>
+            <input  message="tns:retrieveRequest"/>
+            <output message="tns:retrieveResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+            <fault  message="tns:MalformedQueryFault" name="MalformedQueryFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+        </operation>
+
+        <operation name="process">
+            <documentation>Submit an entity to a workflow process or process a workitem</documentation>
+            <input  message="tns:processRequest"/>
+            <output message="tns:processResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+        </operation>
+
+        <operation name="convertLead">
+            <documentation>convert a set of leads</documentation>
+            <input  message="tns:convertLeadRequest"/>
+            <output message="tns:convertLeadResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="logout">
+            <documentation>Logout the current user, invalidating the current session.</documentation>
+            <input  message="tns:logoutRequest"/>
+            <output message="tns:logoutResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="invalidateSessions">
+            <documentation>Logs out and invalidates session ids</documentation>
+            <input  message="tns:invalidateSessionsRequest"/>
+            <output message="tns:invalidateSessionsResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="getDeleted">
+            <documentation>Get the IDs for deleted sObjects</documentation>
+            <input  message="tns:getDeletedRequest"/>
+            <output message="tns:getDeletedResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="getUpdated">
+            <documentation>Get the IDs for updated sObjects</documentation>
+            <input  message="tns:getUpdatedRequest"/>
+            <output message="tns:getUpdatedResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="query">
+            <documentation>Create a Query Cursor</documentation>
+            <input  message="tns:queryRequest"/>
+            <output message="tns:queryResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+            <fault  message="tns:MalformedQueryFault" name="MalformedQueryFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidQueryLocatorFault" name="InvalidQueryLocatorFault"/>
+        </operation>
+
+        <operation name="queryAll">
+            <documentation>Create a Query Cursor, including deleted sObjects</documentation>
+            <input  message="tns:queryAllRequest"/>
+            <output message="tns:queryAllResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+            <fault  message="tns:MalformedQueryFault" name="MalformedQueryFault"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidQueryLocatorFault" name="InvalidQueryLocatorFault"/>
+        </operation>
+
+        <operation name="queryMore">
+            <documentation>Gets the next batch of sObjects from a query</documentation>
+            <input  message="tns:queryMoreRequest"/>
+            <output message="tns:queryMoreResponse"/>
+            <fault  message="tns:InvalidQueryLocatorFault" name="InvalidQueryLocatorFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+            <fault  message="tns:MalformedQueryFault" name="MalformedQueryFault"/>
+        </operation>
+
+        <operation name="search">
+            <documentation>Search for sObjects</documentation>
+            <input  message="tns:searchRequest"/>
+            <output message="tns:searchResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+            <fault  message="tns:MalformedSearchFault" name="MalformedSearchFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="getServerTimestamp">
+            <documentation>Gets server timestamp</documentation>
+            <input  message="tns:getServerTimestampRequest"/>
+            <output message="tns:getServerTimestampResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="setPassword">
+            <documentation>Set a user's password</documentation>
+            <input  message="tns:setPasswordRequest"/>
+            <output message="tns:setPasswordResponse"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+            <fault  message="tns:InvalidNewPasswordFault" name="InvalidNewPasswordFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="resetPassword">
+            <documentation>Reset a user's password</documentation>
+            <input  message="tns:resetPasswordRequest"/>
+            <output message="tns:resetPasswordResponse"/>
+            <fault  message="tns:InvalidIdFault" name="InvalidIdFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="getUserInfo">
+            <documentation>Returns standard information relevant to the current user</documentation>
+            <input  message="tns:getUserInfoRequest"/>
+            <output message="tns:getUserInfoResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="sendEmailMessage">
+            <documentation>Send existing draft EmailMessage</documentation>
+            <input  message="tns:sendEmailMessageRequest"/>
+            <output message="tns:sendEmailMessageResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="sendEmail">
+            <documentation>Send outbound email</documentation>
+            <input  message="tns:sendEmailRequest"/>
+            <output message="tns:sendEmailResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="performQuickActions">
+            <documentation>Perform a series of predefined actions such as quick create or log a task</documentation>
+            <input  message="tns:performQuickActionsRequest"/>
+            <output message="tns:performQuickActionsResponse"/>
+        </operation>
+
+        <operation name="describeQuickActions">
+            <documentation>Describe the details of a series of quick actions</documentation>
+            <input  message="tns:describeQuickActionsRequest"/>
+            <output message="tns:describeQuickActionsResponse"/>
+        </operation>
+
+        <operation name="describeAvailableQuickActions">
+            <documentation>Describe the details of a series of quick actions available for the given contextType</documentation>
+            <input  message="tns:describeAvailableQuickActionsRequest"/>
+            <output message="tns:describeAvailableQuickActionsResponse"/>
+        </operation>
+
+        <operation name="retrieveQuickActionTemplates">
+            <documentation>Retreive the template sobjects, if appropriate, for the given quick action names in a given context</documentation>
+            <input  message="tns:retrieveQuickActionTemplatesRequest"/>
+            <output message="tns:retrieveQuickActionTemplatesResponse"/>
+        </operation>
+
+        <operation name="describeNouns">
+            <documentation>Return the renameable nouns from the server for use in presentation using the salesforce grammar engine</documentation>
+            <input  message="tns:describeNounsRequest"/>
+            <output message="tns:describeNounsResponse"/>
+        </operation>
+
+    </portType>
+
+    <!-- Soap Binding -->
+    <binding name="SoapBinding" type="tns:Soap">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="login">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="LoginScopeHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="LoginFault">
+                <soap:fault name="LoginFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeSObject">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeSObjects">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeGlobal">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeDataCategoryGroups">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeDataCategoryGroupStructures">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeKnowledgeSettings">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeFlexiPages">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeAppMenu">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeGlobalTheme">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeTheme">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeLayout">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeSoftphoneLayout">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeSearchLayouts">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeSearchScopeOrder">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeCompactLayouts">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeApprovalLayout">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeSoqlListViews">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="executeListView">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeSObjectListViews">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeTabs">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeAllTabs">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describePrimaryCompactLayouts">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="create">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="AssignmentRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="DebuggingInfo"/>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="update">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="AssignmentRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
+                <soap:header use="literal" message="tns:Header" part="OwnerChangeOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="DebuggingInfo"/>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="upsert">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="AssignmentRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
+                <soap:header use="literal" message="tns:Header" part="OwnerChangeOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="DebuggingInfo"/>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="merge">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="AssignmentRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="DebuggingInfo"/>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="delete">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="UserTerritoryDeleteHeader"/>
+                <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="DebuggingInfo"/>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="undelete">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="DebuggingInfo"/>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="emptyRecycleBin">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="retrieve">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="QueryOptions"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+            <fault name="MalformedQueryFault">
+                <soap:fault name="MalformedQueryFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="process">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="DebuggingInfo"/>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="convertLead">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="DebuggingInfo"/>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="logout">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="invalidateSessions">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="getDeleted">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="getUpdated">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="query">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="QueryOptions"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+            <fault name="MalformedQueryFault">
+                <soap:fault name="MalformedQueryFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidQueryLocatorFault">
+                <soap:fault name="InvalidQueryLocatorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="queryAll">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="QueryOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+            <fault name="MalformedQueryFault">
+                <soap:fault name="MalformedQueryFault" use="literal"/>
+            </fault>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidQueryLocatorFault">
+                <soap:fault name="InvalidQueryLocatorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="queryMore">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="QueryOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidQueryLocatorFault">
+                <soap:fault name="InvalidQueryLocatorFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+            <fault name="MalformedQueryFault">
+                <soap:fault name="MalformedQueryFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="search">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+            <fault name="MalformedSearchFault">
+                <soap:fault name="MalformedSearchFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="getServerTimestamp">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="setPassword">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+            <fault name="InvalidNewPasswordFault">
+                <soap:fault name="InvalidNewPasswordFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="resetPassword">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidIdFault">
+                <soap:fault name="InvalidIdFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="getUserInfo">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="sendEmailMessage">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="sendEmail">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="performQuickActions">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="AssignmentRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
+                <soap:header use="literal" message="tns:Header" part="OwnerChangeOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeQuickActions">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeAvailableQuickActions">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="retrieveQuickActionTemplates">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeNouns">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="CallOptions"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+
+    </binding>
+
+    <!-- Soap Service Endpoint -->
+    <service name="SforceService">
+        <documentation>Sforce SOAP API</documentation>
+        <port binding="tns:SoapBinding" name="Soap">
+            <soap:address location="https://login.salesforce.com/services/Soap/u/34.0"/>
+        </port>
+    </service>
+</definitions>


### PR DESCRIPTION
This is a breaking change.  Version 31.0 of the API removed `create()`,
`update()` and `destroy()` and replaced them with `createMetadata()`,
`updateMetadata()`, and `destroyMetadata()`.  It also added
`readMetadata()` (and `upsertMetadata()`, which I'm not tackling here),
and made all the CRUD operations synchronous.
