### PR TITLE
Relax version restriction on thor

### DIFF
--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -25,7 +25,7 @@ EOL
   s.add_dependency 'rubyzip', '~> 1.0'
   s.add_dependency 'activesupport'
   s.add_dependency 'hashie', '~> 1.2.0'
-  s.add_dependency 'thor', '~> 0.14.0'
+  s.add_dependency 'thor', '>= 0.14.0'
   s.add_dependency 'listen', '~> 0.6.0'
   s.add_dependency 'rb-fsevent', '~> 0.9.1'
   s.add_dependency 'faraday'


### PR DESCRIPTION
The original repo has "~> 0.16.0".
Our fork had "~> 0.14.0" to be compatible with some apps.
Tests all pass when bundled with "0.19.1".
